### PR TITLE
Add lane departure warning to visual hud alerts

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -266,6 +266,7 @@ struct CarControl {
       wrongGear @4;
       seatbeltUnbuckled @5;
       speedTooHigh @6;
+      ldw @7;
     }
 
     enum AudibleAlert {


### PR DESCRIPTION
A follow up PR for openpilot and opendbc (for Honda maybe with a refactor for Toyota) will be coming soon.