### PR TITLE
Add fields and states required for robust Volkswagen safety compliance

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -19,7 +19,6 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   immediateDisable @6 :Bool;
   preEnable @7 :Bool;
   permanent @8 :Bool;
-  preEntry @9: Bool;
 
   enum EventName @0xbaa8c5d505f727de {
     # TODO: copy from error list

--- a/car.capnp
+++ b/car.capnp
@@ -19,6 +19,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   immediateDisable @6 :Bool;
   preEnable @7 :Bool;
   permanent @8 :Bool;
+  preEntry @9: Bool;
 
   enum EventName @0xbaa8c5d505f727de {
     # TODO: copy from error list
@@ -163,6 +164,8 @@ struct CarState {
     sport @5;
     low @6;
     brake @7;
+    eco @8;
+    manumatic @9;
   }
 
 
@@ -181,6 +184,11 @@ struct CarState {
       altButton1 @6;
       altButton2 @7;
       altButton3 @8;
+      setCruise @9;
+      resumeCruise @10;
+      gapAdjustCruise @11;
+      increaseCruise @12;
+      decreaseCruise @13;
     }
   }
 }
@@ -408,7 +416,7 @@ struct CarParams {
     gmPassive @12;
     mazda @13;
     nissan @14;
-    vw @15;
+    volkswagen @15;
   }
 
   enum SteerControlType {

--- a/car.capnp
+++ b/car.capnp
@@ -187,8 +187,6 @@ struct CarState {
       setCruise @9;
       resumeCruise @10;
       gapAdjustCruise @11;
-      increaseCruise @12;
-      decreaseCruise @13;
     }
   }
 }


### PR DESCRIPTION
This is the first in a series of PRs to upstream the Volkswagen, Audi, SEAT, and Škoda community port. However, almost all of these changes could be useful for other manufacturer ports.

Additional PRs will be opened for OpenDBC, Panda safety, and OP updates in due course. I am filing this one first to avoid breaking your upload and ingest pipeline. I will make the corresponding changes in our port if and when you merge this PR.

**Add generic (manufacturer-independent) cruise-control button events in support of enhanced steering wheel or third stalk ACC control.**

This change is required because our button semantics are different. Our cars DO NOT have the traditional overloaded res/accel or set/coast buttons; the Res and Set buttons behave exactly as labeled whether momentarily pressed or held. Res will not accelerate, and Set will not decelerate. The increase and decrease buttons usually adjust the ACC speed setpoint, but are temporarily mode-switched to following distance if the driver presses the gap adjust button. The speed setpoint CAN BE changed with ACC disengaged, and the act of changing it DOES NOT engage ACC.

In the short term, we need to be able to flow these button press events up into controlsd, if for no other reason than resetting the DM timer at night. We should be able to press the Res button as a DM reset no-op, without having it treated as accel with the wrong behavior. In the long term, when we tackle longitudinal control, we'll need to handle each of these individual buttons correctly. I understand that Comma has no intent to support manual gap adjustment for native longitudinal, but we still need it for stock.

For the reasons above, we cannot (ab)use the existing controlsd behavior for accelCruise and decelCruise Events. I am handling part of it with altButton1/2/3 today, but with poor clarity and obvious functional compromise, since we can only do that with three of the five buttons. 

**Add generic (manufacturer-independent) gearshift position definitions for Eco and Manumatic.**

Definitions exist today for Sport and Low. I am currently lying to OP by saying Eco is Drive and Tiptronic is Sport; we would like to handle this more correctly and clearly. [Manumatic](https://en.wikipedia.org/wiki/Manumatic) is the best generic (manufacturer-independent) name available for manually-shifted automatic transmissions.

**Add a preEntry Event state, in support of generic (manufacturer-independent) strict safety model compliance.**

Our port obeys Comma's strict safety model, which has conditions beyond stock ACC requirements. I want to make sure failed engage attempts show something on the OP display about why. Doing this "right", preventing stock ACC from ever being engaged if there's a Comma safety model fail for which stock ACC would still work, cannot be done reliably without an architectural tweak (I tried!). The way [Honda does it](https://github.com/jyoung8607/openpilot/blob/vw-063-devel/selfdrive/car/honda/interface.py#L536) still lets stock ACC engage, even if briefly, and engaging OP before stock creates a timing race for controls mismatch.

My proposal is to add a preEntry state, a sort of companion to preEnable. Any port could raise a buttonEnable event with PRE_ENTRY set, as a signal for controlsd to show NO_ENTRY alerts without _necessarily_ engaging OP at that moment. If this proposal is accepted and merged, I'll submit a follow-up PR to update the Disabled logic in controlsd state_transition().

**Update the Volkswagen safety model ID from "vw" to "volkswagen" to be consistent with the existing community port.**

No justification other than personal preference, as the guy doing much of the work here, and the fact I'd have to go back and do a ton of renaming. Help me out here? :)

**Separately, please consider merging #3 for generic (manufacturer-independent) support of manual transmissions.**

Again I can understand they might not be first class Comma supported, but we already have manual transmission users on the community Volkswagen port, and right now we're having to pretend they're in Drive all the time. We'd like to give them better safety handling, and surely your upload and ingest pipeline will appreciate not being lied to... if nothing else, this will give you a handy marker to identify them and toss the data if you don't want it!