### PR TITLE
Switch from polling on FIFOs to signal

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,5 @@
+pr: none
+
 pool:
   vmImage: 'ubuntu-16.04'
 

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -414,18 +414,16 @@ int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
     if (items[i].revents) num++;
   }
 
+  int ms = (timeout == -1) ? 100 : timeout;
+  struct timespec ts;
+  ts.tv_sec = ms / 1000;
+  ts.tv_nsec = (ms % 1000) * 1000 * 1000;
+
 
   while (num == 0) {
-    // TODO: if a message is ready on any of the sockets, don't sleep
-    // TODO: switch to nanosleep and store remaining time in case there is a false positive
-
     int ret;
-    if (timeout == -1) {
-      ret = usleep(100*1000);
-    } else {
-      ret = usleep(timeout*1000);
-    }
 
+    ret = nanosleep(&ts, &ts);
 
     // Check if messages ready
     for (size_t i = 0; i < nitems; i++) {

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -405,7 +405,8 @@ int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
       num += msgq_msg_ready(items[i].q);
     }
 
-    if (timeout == -1 && ret != EINTR) break;
+    // exit if we had a timeout and the sleep finished
+    if (timeout != -1 && ret != EINTR) break;
   }
 
   return num;

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -390,19 +390,22 @@ int msgq_msg_recv(msgq_msg_t * msg, msgq_queue_t * q){
 
 int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
   assert(timeout >= 0);
-
   int num = 0;
 
-  // block on signal or timeout
-  if (timeout == -1) {
-    while(1) { if (usleep(1000*1000) == EINTR) break; }
-  } else {
-    usleep(timeout*1000);
-  }
+  while (num == 0) {
+    int ret;
+    if (timeout == -1) {
+      ret = usleep(1000*1000);
+    } else {
+      ret = usleep(timeout*1000);
+    }
 
-  // get number to return
-  for (size_t i = 0; i < nitems; i++) {
-    num += msgq_msg_ready(items[i].q);
+    // get number to return
+    for (size_t i = 0; i < nitems; i++) {
+      num += msgq_msg_ready(items[i].q);
+    }
+
+    if (timeout == -1 && ret != EINTR) break;
   }
 
   return num;

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -144,6 +144,8 @@ void msgq_init_subscriber(msgq_queue_t * q) {
   assert(q != NULL);
   assert(q->num_readers != NULL);
 
+  // TODO: Setup empty SIGUSR1 handler
+
   uint64_t uid = getpid();
 
   // Get reader id
@@ -393,6 +395,10 @@ int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
   int num = 0;
 
   while (num == 0) {
+    //TODO: if a message is ready on any of the sockets, don't sleep
+
+
+    // TODO: switch to nanosleep and store remaining time
     int ret;
     if (timeout == -1) {
       ret = usleep(1000*1000);

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -406,11 +406,14 @@ int msgq_msg_recv(msgq_msg_t * msg, msgq_queue_t * q){
 int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
   assert(timeout >= 0);
 
-  for (size_t i = 0; i < nitems; i++){
-    items[i].revents = 0;
+  int num = 0;
+
+  // Check if messages ready
+  for (size_t i = 0; i < nitems; i++) {
+    items[i].revents = msgq_msg_ready(items[i].q);
+    if (items[i].revents) num++;
   }
 
-  int num = 0;
 
   while (num == 0) {
     // TODO: if a message is ready on any of the sockets, don't sleep

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -5,7 +5,6 @@
 #include <cstring>
 #include <cstdint>
 #include <chrono>
-#include <random>
 #include <algorithm>
 #include <cstdlib>
 
@@ -140,9 +139,7 @@ void msgq_close_queue(msgq_queue_t *q){
 void msgq_init_publisher(msgq_queue_t * q) {
   std::cout << "Starting publisher" << std::endl;
 
-  std::random_device rd("/dev/urandom");
-  std::uniform_int_distribution<uint64_t> distribution(0,std::numeric_limits<uint64_t>::max());
-  uint64_t uid = distribution(rd);
+  uint64_t uid = getpid();
 
   *q->write_uid = uid;
   *q->num_readers = 0;
@@ -161,9 +158,7 @@ void msgq_init_subscriber(msgq_queue_t * q) {
   assert(q != NULL);
   assert(q->num_readers != NULL);
 
-  std::random_device rd("/dev/urandom");
-  std::uniform_int_distribution<uint64_t> distribution(0,std::numeric_limits<uint64_t>::max());
-  uint64_t uid = distribution(rd);
+  uint64_t uid = getpid();
 
   // Get reader id
   while (true){

--- a/messaging/msgq.hpp
+++ b/messaging/msgq.hpp
@@ -35,14 +35,7 @@ struct msgq_queue_t {
   uint64_t write_uid_local;
 
   bool read_conflate;
-  int read_fifo;
-
-  // Fifo fds and corresponding reader uid
-  int read_fifos[NUM_READERS];
-  uint64_t read_fifos_uid[NUM_READERS];
-
   std::string endpoint;
-  std::string read_fifo_path;
 };
 
 struct msgq_msg_t {

--- a/messaging/tests/test_poller.py
+++ b/messaging/tests/test_poller.py
@@ -15,7 +15,7 @@ def poller():
   sub.connect(context, 'controlsState')
   p.registerSocket(sub)
 
-  socks = p.poll(1000)
+  socks = p.poll(10000)
   r = [s.receive(non_blocking=True) for s in socks]
 
   return r
@@ -44,7 +44,6 @@ class TestPoller(unittest.TestCase):
 
     self.assertEqual(result, [b"a"])
 
-  @unittest.skipIf(os.environ.get('MSGQ'), "fails under msgq")
   def test_poll_and_create_many_subscribers(self):
     context = messaging.Context()
 
@@ -69,3 +68,7 @@ class TestPoller(unittest.TestCase):
     context.term()
 
     self.assertEqual(result, [b"a"])
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/messaging/tests/test_poller.py
+++ b/messaging/tests/test_poller.py
@@ -58,6 +58,8 @@ class TestPoller(unittest.TestCase):
       for _ in range(10):
         messaging.SubSocket().connect(c, 'controlsState')
 
+      time.sleep(0.1)
+
       # Send message
       pub.send("a")
 


### PR DESCRIPTION
First off, remove randomness unless there's a real justification for it. In general, unless you absolutely need it, randomness shouldn't be used.

Secondly, with uids being pids, I think the signalling solution is obvious. The polling process can sleep until the publishing process decides it's time to wake it up. I don't know the nuance here, but usleep can be exited by EINTR, though I think the signal handler might have to be configured to do that.

You could get more fine grained with the poll, where the subscriber says if it's blocked on a given socket to avoid spurious wakeups (right now it wakes on all subscribed sockets), but this is a perf optimization for later and maybe not needed at all.

Right now this segfaults with python demo.py, and I don't know why. In general, this software needs a much better test suite, it underlies all of system stability and has to deal with many different orders of events.
