### PR TITLE
Remove ZMQ publish socket assert() from messaging layer

### DIFF
--- a/messaging/impl_zmq.cc
+++ b/messaging/impl_zmq.cc
@@ -111,7 +111,7 @@ void ZMQPubSocket::connect(Context *context, std::string endpoint){
 
   //std::cout << "ZMQ PUB: " << full_endpoint << std::endl;
 
-  assert(zmq_bind(sock, full_endpoint.c_str()) == 0);
+  zmq_bind(sock, full_endpoint.c_str());
 }
 
 int ZMQPubSocket::sendMessage(Message *message){


### PR DESCRIPTION
# Bug Fix

This duplicates PR commaai/openpilot#884 in the new home of the messaging library to make sure the fix is preserved beyond OP 0.6.6.