### PR TITLE
Reserve safety ID 21 for VAG PQ35/PQ46

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -431,6 +431,7 @@ struct CarParams {
     gmAscm @18;
     noOutput @19;  # like silent but without silent CAN TXs
     hondaBoschHarness @20;
+    volkswagenPq @21;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
The community Volkswagen port is developing support for older Volkswagen, Audi, SEAT and Škoda vehicles. We now have a 2009 Volkswagen Passat R36 up and running successfully in a test branch.

https://my.comma.ai/useradmin/explorer?route=d12cd943127f267b%7C2019-12-29--15-09-02

Their networking concept is a first cousin of MQB, similar enough that we can share one reasonably clean OP port, but different enough to justify a different Panda safety with different regression tests.

Cars this will eventually support:
PQ35: https://en.wikipedia.org/wiki/Volkswagen_Group_A_platform#PQ35_(A5)
PQ46: https://en.wikipedia.org/wiki/Volkswagen_Group_B_platform#PQ46_(A6) (includes NMS)

The safety code will be upstreamed when completed. I expect the OP port to reach upstreamable quality at some point, but won't be submitted until verified with Black Panda / Car Harness.