### PR TITLE
Add `wait_for` input parameter to SubMaster

### DIFF
--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -222,16 +222,6 @@ class PubMaster():
     for s in services:
       self.sock[s] = pub_sock(s)
 
-  def new_message(self, service, size=None):
-    dat = log.Event.new_message()
-    dat.logMonoTime = int(sec_since_boot() * 1e9)
-    dat.valid = True
-    if size is not None:
-      dat.init(service, size)
-    else:
-      dat.init(service)
-    return dat
-
   def send(self, s, dat):
     # accept either bytes or capnp builder
     if not isinstance(dat, bytes):

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -147,10 +147,10 @@ class SubMaster():
       self.wait_for = wait_for
 
     for s in services:
-      if addr is not None and s in self.wait_for:
-        self.sock[s] = {'sock': sub_sock(s, addr=addr, conflate=True), 'wait': True}
-      elif addr is not None:
+      if addr is not None and s not in self.wait_for:
         self.sock[s] = {'sock': sub_sock(s, poller=self.poller, addr=addr, conflate=True), 'wait': False}
+      elif addr is not None:
+        self.sock[s] = {'sock': sub_sock(s, addr=addr, conflate=True), 'wait': True}
       self.freq[s] = service_list[s].frequency
 
       data = new_message()

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -170,8 +170,7 @@ class SubMaster():
   def update(self, timeout=1000):
     msgs = []
     for sock in self.poller.poll(timeout):
-      msg = recv_one_or_none(sock)
-      msgs.append(msg)
+      msgs.append(recv_one_or_none(sock))
     for service in self.sock:
       if self.sock[service]['wait']:
         msgs.append(recv_one(self.sock[service]['sock']))
@@ -222,6 +221,13 @@ class PubMaster():
     self.sock = {}
     for s in services:
       self.sock[s] = pub_sock(s)
+
+  def new_message(self, service):
+    dat = log.Event.new_message()
+    dat.logMonoTime = int(sec_since_boot() * 1e9)
+    dat.valid = True
+    dat.init(service)
+    return dat
 
   def send(self, s, dat):
     # accept either bytes or capnp builder

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -222,11 +222,14 @@ class PubMaster():
     for s in services:
       self.sock[s] = pub_sock(s)
 
-  def new_message(self, service):
+  def new_message(self, service, size=None):
     dat = log.Event.new_message()
     dat.logMonoTime = int(sec_since_boot() * 1e9)
     dat.valid = True
-    dat.init(service)
+    if size is not None:
+      dat.init(service, size)
+    else:
+      dat.init(service)
     return dat
 
   def send(self, s, dat):


### PR DESCRIPTION
1. Add input parameter `wait_for` which takes a list of services to wait for when updating with the SubMaster.
   Example:
   ```python
   sm = messaging.SubMaster(['testStruct', 'thermal'], wait_for=['testStruct'])
   sm.update(0)  #  waits until new message from testStruct is received
   print('Updated: {}'.format(sm.updated['testStruct']))  # this should always return True
   ```

@pd0wm I tried what you suggested, only adding the poller to the services to wait for but that resulted in completely skipping those services if there wasn't a new message waiting to be received. So I did the opposite which is what I think you meant to say; for services to wait for, I did not specify a poller and instead in the update function of SM, I used `recv_one` instead of `recv_one_or_none`. This also required changing the `sock` class variable to include a `wait` flag so I could target those sockets in the update function after the fact.

No performance hit should be taken if there are no messages to be waiting for, other than iterating through the dictionary checking for the `wait` key. This could also be skipped by adding an if check above the `for service in self.sock:` loop checking if `self.wait_for` is None.