### PR TITLE
Add none network strength

### DIFF
--- a/log.capnp
+++ b/log.capnp
@@ -316,6 +316,7 @@ struct ThermalData {
     moderate @2;
     good @3;
     great @4;
+    none @5;
   }
 }
 


### PR DESCRIPTION
> Error getting network status
Traceback (most recent call last):
  File "/data/openpilot/selfdrive/thermald.py", line 202, in thermald_thread
    network_strength = get_network_strength(network_type)
  File "/data/openpilot/common/android.py", line 236, in get_network_strength
    network_strength = NetworkStrength.none
AttributeError: '_EnumModule' object has no attribute 'none'
