### PR TITLE
Additional car params auto-detection in support of VW

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -459,7 +459,7 @@ struct CarParams {
     unknown @0;
     automatic @1;  # Traditional auto, including DSG
     manual @2;  # True "stick shift" only
-    none @3;  # Electric vehicle or other direct drive
+    direct @3;  # Electric vehicle or other direct drive
   }
 
   struct CarFw {

--- a/car.capnp
+++ b/car.capnp
@@ -457,8 +457,9 @@ struct CarParams {
 
   enum TransmissionType {
     unknown @0;
-    automatic @1;
-    manual @2;
+    automatic @1;  # Traditional auto, including DSG
+    manual @2;  # True "stick shift" only
+    none @3;  # Electric vehicle or other direct drive
   }
 
   struct CarFw {

--- a/car.capnp
+++ b/car.capnp
@@ -151,7 +151,7 @@ struct CarState {
 
   # which packets this state came from
   canMonoTimes @12: List(UInt64);
-  
+
   # blindspot sensors
   leftBlindspot @33 :Bool; # Is there something blocking the left lane change
   rightBlindspot @34 :Bool; # Is there something blocking the right lane change
@@ -379,6 +379,7 @@ struct CarParams {
   radarTimeStep @45: Float32 = 0.05;  # time delta between radar updates, 20Hz is very standard
   communityFeature @46: Bool;  # true if a community maintained feature is detected
   fingerprintSource @49: FingerprintSource;
+  networkLocation @50 :NetworkLocation;  # Where Panda/C2 is integrated into the car's CAN network
 
   struct LateralParams {
     torqueBP @0 :List(Int32);
@@ -495,5 +496,10 @@ struct CarParams {
     can @0;
     fw @1;
     fixed @2;
+  }
+
+  enum NetworkLocation {
+    fwdCamera @0;  # Standard/default integration at LKAS camera
+    gateway @1;    # Integration at vehicle's CAN gateway
   }
 }


### PR DESCRIPTION
Allow auto-detection of some important params in preparation for decent VW fingerprinting. These are things we need to discover up-front in get_params() and preserve for later use.

- Add Enum for installed network location, so we can handle folks wired to the camera (R242) vs the gateway (J533). I know Comma likes standard camera integration, but gateway integrations are a popular, growing, and essential "fact on the ground". All we need is a CarParams flag so that when we need to, we can relocate one (1) CarState signal and retarget one (1) CarController can_sends.

- Add an electric vehicle variant to the transmission type Enum. Turns out for true EVs (not hybrids) we have to learn the gearshift lever position from an EV-specific signal.