### PR TITLE
Update service documentation in service_list.yaml

### DIFF
--- a/service_list.yaml
+++ b/service_list.yaml
@@ -103,18 +103,30 @@ testJoystick: [8056, false, 0.]
 # gpsd -- publishes EON's gps
 #   publishes: gpsNMEA
 
-# visiond -- talks to the cameras, runs the model, saves the videos
-#   publishes:  frame, model, driverMonitoring, cameraOdometry, thumbnail
+# camerad -- publishes camera frames
+#   publishes: frame, frontFrame, thumbnail
+#   subscribes: driverState
+
+# dmonitoringmodeld -- runs face detection on camera frames
+#   publishes: driverState
 
 # **** stateful data transformers ****
+
+# modeld -- runs & publishes the model 
+#   publishes: model, cameraOdometry
+#   subscribes: liveCalibration, pathPlan
 
 # plannerd -- decides where to drive the car
 #   subscribes: carState, model, radarState, controlsState, liveParameters
 #   publishes:  plan, pathPlan, liveMpc, liveLongitudinalMpc
 
 # controlsd -- drives the car by sending CAN messages to panda
-#   subscribes: can, thermal, health, plan, pathPlan, driverMonitoring, liveCalibration
+#   subscribes: can, thermal, health, plan, pathPlan, dMonitoringState, liveCalibration, model
 #   publishes:  carState, carControl, sendcan, controlsState, carEvents, carParams
+
+# dmonitoringd -- processes driver monitoring data and publishes driver awareness
+#   subscribes: driverState, liveCalibration, carState, model, gpsLocation
+#   publishes: dMonitoringState
 
 # radard -- processes the radar and vision data
 #   subscribes: can, controlsState, model, liveParameters


### PR DESCRIPTION
Minor change, but the documentation in service_list.yaml has been tremendously helpful in figuring out which process uses which service, so I updated it to reflect recent changes in openpilot.