### PR TITLE
Fix potential segfault in MSGQPubSocket::connect

### DIFF
--- a/messaging/impl_msgq.cc
+++ b/messaging/impl_msgq.cc
@@ -143,7 +143,11 @@ int MSGQPubSocket::connect(Context *context, std::string endpoint){
   assert(context);
 
   q = new msgq_queue_t;
-  msgq_new_queue(q, endpoint.c_str(), DEFAULT_SEGMENT_SIZE);
+  int r = msgq_new_queue(q, endpoint.c_str(), DEFAULT_SEGMENT_SIZE);
+  if (r != 0){
+    return r;
+  }
+
   msgq_init_publisher(q);
 
   return 0;

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -90,8 +90,10 @@ int msgq_new_queue(msgq_queue_t * q, const char * path, size_t size){
   auto fd = open(full_path, O_RDWR | O_CREAT, 0777);
   delete[] full_path;
 
-  if (fd < 0)
+  if (fd < 0) {
+    std::cout << "Warning, could not open: " << full_path << std::endl;
     return -1;
+  }
 
   int rc = ftruncate(fd, size + sizeof(msgq_header_t));
   if (rc < 0)


### PR DESCRIPTION
While playing with openpilot tools on Mac (concretely unlogger.py) there was a silent failure caused by absence of `/dev/shm` and resulting segfault due to accessing uninitialized memory in `msgq_init_publisher`.

This caused me to lose some time trying to debug this - hopefully making the failure explicit saves someone time in the future.