### PR TITLE
Add class SubMessage

### DIFF
--- a/messaging/messaging.hpp
+++ b/messaging/messaging.hpp
@@ -103,8 +103,8 @@ private:
   Poller *poller_ = nullptr;
   uint64_t frame_ = 0;
   struct Message;
-  std::map<SubSocket *, Message *> messages_;
-  std::map<std::string, Message *> services_;
+  std::map<SubSocket *, SubMaster::Message *> messages_;
+  std::map<std::string, SubMaster::Message *> services_;
 };
 
 class MessageBuilder : public capnp::MallocMessageBuilder {

--- a/messaging/socketmaster.cc
+++ b/messaging/socketmaster.cc
@@ -53,7 +53,7 @@ bool SubMessage::receive(bool non_blocking) {
   if (msg_reader_) {
     msg_reader_->~FlatArrayMessageReader();
   }
-  msg_reader_ = new (allocated_msg_reader_) capnp::FlatArrayMessageReader(kj::ArrayPtr<capnp::word>(alignedBuffer_.begin(), size));
+  msg_reader_ = new (allocated_msg_reader_) capnp::FlatArrayMessageReader(alignedBuffer_.slice(0, size));
   event_ = msg_reader_->getRoot<cereal::Event>();
   return true;
 }

--- a/messaging/socketmaster.cc
+++ b/messaging/socketmaster.cc
@@ -31,58 +31,48 @@ public:
 };
 MessageContext ctx;
 
-SubMessage::SubMessage(const char *name, const char *address, bool conflate) : name_(name) {
-  alignedBuffer_ = kj::heapArray<capnp::word>(1024);
-  allocated_msg_reader_ = malloc(sizeof(capnp::FlatArrayMessageReader));
+SubMessage::SubMessage(const char *name, const char *address, int timeout, bool conflate) : name(name) {
+  buf = kj::heapArray<capnp::word>(1024);
+  allocated_msg_reader = malloc(sizeof(capnp::FlatArrayMessageReader));
 
-  socket_ = SubSocket::create(ctx.ctx_, name, address ? address : "127.0.0.1", conflate);
-  assert(socket_ != nullptr);
+  socket = SubSocket::create(ctx.ctx_, name, address ? address : "127.0.0.1", conflate);
+  assert(socket != nullptr);
+  if (timeout > 0) {
+    socket->setTimeout(timeout);
+  }
 }
 
-bool SubMessage::receive(bool non_blocking) {
-  Message *msg = socket_->receive(non_blocking);
-  if (msg == NULL) return false;
+std::optional<cereal::Event::Reader> SubMessage::receive(bool non_blocking) {
+  Message *msg = socket->receive(non_blocking);
+  if (msg == nullptr) return std::nullopt;
 
   const size_t size = (msg->getSize() + sizeof(capnp::word) - 1) / sizeof(capnp::word);
-  if (alignedBuffer_.size() < size) {
-    alignedBuffer_ = kj::heapArray<capnp::word>(size);
+  if (buf.size() < size) {
+    buf = kj::heapArray<capnp::word>(size);
   }
-  memcpy(alignedBuffer_.begin(), msg->getData(), msg->getSize());
-  delete msg;
+  memcpy(buf.begin(), msg->getData(), msg->getSize());
 
-  if (msg_reader_) {
-    msg_reader_->~FlatArrayMessageReader();
+  if (msg_reader) {
+    msg_reader->~FlatArrayMessageReader();
   }
-  msg_reader_ = new (allocated_msg_reader_) capnp::FlatArrayMessageReader(alignedBuffer_.slice(0, size));
-  event_ = msg_reader_->getRoot<cereal::Event>();
-  return true;
+  msg_reader = new (allocated_msg_reader) capnp::FlatArrayMessageReader(buf.slice(0, size));
+  event = msg_reader->getRoot<cereal::Event>();
+
+  return std::make_optional(event);
 }
 
+
 void SubMessage::drain() {
-  while (true) {
-    Message *msg = socket_->receive(true);
-    if (msg == NULL) break;
-    
-    delete msg;
-  }
+  while (receive(true)) { /* empty */ }
 }
 
 SubMessage::~SubMessage() {
-  if (msg_reader_) {
-    msg_reader_->~FlatArrayMessageReader();
+  if (msg_reader) {
+    msg_reader->~FlatArrayMessageReader();
   }
-  free(allocated_msg_reader_);
-  delete socket_;
+  free(allocated_msg_reader);
+  delete socket;
 }
-
-struct SubMaster::Message {
-  Message(const char *name, const char *address, int freq, bool ignore_alive)
-      : message(name, address, true), freq(freq), ignore_alive(ignore_alive) {}
-  SubMessage message;
-  int freq = 0;
-  bool updated = false, alive = false, ignore_alive = false;
-  uint64_t rcv_time = 0, rcv_frame = 0;
-};
 
 SubMaster::SubMaster(const std::initializer_list<const char *> &service_list, const char *address,
                      const std::initializer_list<const char *> &ignore_alive) {
@@ -90,24 +80,12 @@ SubMaster::SubMaster(const std::initializer_list<const char *> &service_list, co
   for (auto name : service_list) {
     const service *serv = get_service(name);
     assert(serv != nullptr);
-<<<<<<< HEAD
-    SubSocket *socket = SubSocket::create(ctx.ctx_, name, address ? address : "127.0.0.1", true);
-    assert(socket != 0);
-    poller_->registerSocket(socket);
-    SubMessage *m = new SubMessage{
-      .socket = socket,
-      .freq = serv->frequency,
-      .ignore_alive = inList(ignore_alive, name),
-      .allocated_msg_reader = malloc(sizeof(capnp::FlatArrayMessageReader)),
-      .buf = kj::heapArray<capnp::word>(1024)};
-    messages_[socket] = m;
-=======
+    SubMessage *m = new SubMessage(name, address, 0, true);
+    m->freq = serv->frequency;
+    m->ignore_alive = inList(ignore_alive, name);
 
-    SubMaster::Message *m = new SubMaster::Message(name, address, serv->frequency, inList(ignore_alive, name));
-    poller_->registerSocket(m->message.socket_);
-    messages_[m->message.socket_] = m;
->>>>>>> finish
-    services_[name] = m;
+    poller_->registerSocket(m->socket);
+    services_[name] = messages_[m->socket] = m;
   }
 }
 
@@ -119,38 +97,40 @@ int SubMaster::update(int timeout) {
   auto sockets = poller_->poll(timeout);
   uint64_t current_time = nanos_since_boot();
   for (auto s : sockets) {
-    SubMaster::Message *m = messages_.at(s);
-    if (!m->message.receive(true)) continue;
+    SubMessage *m = messages_.at(s);
+    if (!m->receive(true)) continue;
 
     m->updated = true;
     m->rcv_time = current_time;
-    m->rcv_frame = frame_;
+    m->rcv_frame = frame;
+    m->valid = m->event.getValid();
+
     ++updated;
   }
 
   for (auto &kv : messages_) {
-    SubMaster::Message *m = kv.second;
+    SubMessage *m = kv.second;
     m->alive = (m->freq <= (1e-5) || ((current_time - m->rcv_time) * (1e-9)) < (10.0 / m->freq));
   }
   return updated;
 }
 
 bool SubMaster::all_(const std::initializer_list<const char *> &service_list, bool valid, bool alive) {
-  int found = 0;
   for (auto &kv : messages_) {
-    SubMaster::Message *m = kv.second;
-    if (service_list.size() == 0 || inList(service_list, m->message.name_.c_str())) {
-      found += (!valid || m->message.getEvent().getValid()) && (!alive || (m->alive && !m->ignore_alive));
+    SubMessage *m = kv.second;
+    if (service_list.size() > 0 && !inList(service_list, m->name.c_str())) continue;
+
+    if ((valid && !m->valid) || (alive && !(m->alive && !m->ignore_alive))) {
+      return false;
     }
   }
-  return service_list.size() == 0 ? found == messages_.size() : found == service_list.size();
+  return true;
 }
 
 void SubMaster::drain() {
   while (true) {
     auto polls = poller_->poll(0);
-    if (polls.size() == 0)
-      break;
+    if (polls.size() == 0) break;
 
     for (auto sock : polls) {
       delete sock->receive(true);
@@ -158,15 +138,21 @@ void SubMaster::drain() {
   }
 }
 
-bool SubMaster::updated(const char *name) const { return services_.at(name)->updated; }
+bool SubMaster::updated(const char *name) const {
+  return services_.at(name)->updated;
+}
 
-const cereal::Event::Reader &SubMaster::operator[](const char *name) { return services_.at(name)->message.getEvent(); };
+uint64_t SubMaster::rcv_frame(const char *name) const {
+  return services_.at(name)->rcv_frame;
+}
+
+cereal::Event::Reader &SubMaster::operator[](const char *name) {
+  return services_.at(name)->event;
+};
 
 SubMaster::~SubMaster() {
   delete poller_;
-  for (auto &kv : messages_) {
-    delete kv.second;
-  }
+  for (auto &kv : messages_) delete kv.second;
 }
 
 PubMaster::PubMaster(const std::initializer_list<const char *> &service_list) {


### PR DESCRIPTION
Add class SubMessage to handle single SubSocket. refactor SubMaster to using SubMessage internally

**non conflated**
```c++
SubMessage msg( "sensorEvents");
if (msg.receive()) {
  cereal::Event::Reader &r = msg.getEvent();
}
```

**conflated**
```c++
SubMessage msg( "sensorEvents", "127.0.0.1", true);
if (msg.receive()) {
  cereal::Event::Reader &r = msg.getEvent();
}
```