### PR TITLE
Messaging unit tests

### DIFF
--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -20,7 +20,7 @@ def random_bytes(length=1000):
   return bytes([random.randrange(0xFF) for _ in range(length)])
 
 def zmq_sleep():
-  if os.environ["ZMQ"] is not None:
+  if "ZMQ" in os.environ:
     time.sleep(1)
 
 # TODO: test both msgq and zmq

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -17,7 +17,7 @@ def random_socks(num_socks=10):
   return list(set([random_sock() for _ in range(num_socks)]))
 
 def random_bytes(length=1000):
-  return bytes([random.randrange(0xFF) for __ in range(length)])
+  return bytes([random.randrange(0xFF) for _ in range(length)])
 
 def zmq_sleep():
   if os.environ["ZMQ"] is not None:

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import time
+import random
+import unittest
+
+import cereal.messaging as messaging
+from cereal.services import service_list
+
+def random_sock():
+  return random.choice(list(service_list.keys()))
+
+def random_bytes(length=1000):
+  return bytes([random.randrange(0xFF) for __ in range(length)])
+
+# TODO: test both msgq and zmq
+
+class TestPubSubSockets(unittest.TestCase):
+
+  def test_pub_sub(self):
+    sock = random_sock()
+    pub_sock = messaging.pub_sock(sock)
+    sub_sock = messaging.sub_sock(sock, conflate=False, timeout=None)
+
+    for _ in range(1000):
+      msg = random_bytes()
+      pub_sock.send(msg)
+      recvd = sub_sock.receive()
+      self.assertEqual(msg, recvd)
+
+  def test_conflate(self):
+    for conflate in [True, False]:
+      for _ in range(10):
+        sock = random_sock()
+        num_msgs = random.randint(3, 10)
+        pub_sock = messaging.pub_sock(sock)
+        sub_sock = messaging.sub_sock(sock, conflate=conflate, timeout=None)
+
+        sent_msgs = []
+        for __ in range(num_msgs):
+          msg = random_bytes()
+          pub_sock.send(msg)
+          sent_msgs.append(msg)
+        time.sleep(0.1)
+        recvd_msgs = messaging.drain_sock_raw(sub_sock)
+        if conflate:
+          self.assertEqual(len(recvd_msgs), 1)
+        else:
+          # TODO: compare actual data
+          self.assertEqual(len(recvd_msgs), len(sent_msgs))
+
+  def test_timeout(self):
+    for _ in range(10):
+      sock = random_sock()
+      timeout = random.randrange(200)
+      pub_sock = messaging.pub_sock(sock)
+      sub_sock = messaging.sub_sock(sock, timeout=timeout)
+
+      start_time = time.monotonic()
+      recvd = sub_sock.receive()
+      self.assertLess(time.monotonic() - start_time, 0.2)
+      assert recvd is None
+
+class TestSubMaster(unittest.TestCase):
+
+  def test_update(self):
+    pass
+
+class TestPubMaster(unittest.TestCase):
+  pass
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -67,6 +67,9 @@ class TestPubSubSockets(unittest.TestCase):
 
 class TestSubMaster(unittest.TestCase):
 
+  def test_init(self):
+    messaging.SubMaster(events)
+
   def test_init_state(self):
     sm = messaging.SubMaster(random_socks())
     self.assertEquals(sm.frame, -1)
@@ -89,6 +92,9 @@ class TestSubMaster(unittest.TestCase):
     pass
 
 class TestPubMaster(unittest.TestCase):
+
+  def test_init(self):
+    messaging.PubMaster(events)
 
   def test_send(self):
     socks = random_socks()

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import time
 import random
 import unittest
@@ -18,6 +19,10 @@ def random_socks(num_socks=10):
 def random_bytes(length=1000):
   return bytes([random.randrange(0xFF) for __ in range(length)])
 
+def zmq_sleep():
+  if os.environ["ZMQ"] is not None:
+    time.sleep(1)
+
 # TODO: test both msgq and zmq
 
 class TestPubSubSockets(unittest.TestCase):
@@ -26,6 +31,7 @@ class TestPubSubSockets(unittest.TestCase):
     sock = random_sock()
     pub_sock = messaging.pub_sock(sock)
     sub_sock = messaging.sub_sock(sock, conflate=False, timeout=None)
+    zmq_sleep()
 
     for _ in range(1000):
       msg = random_bytes()
@@ -40,6 +46,7 @@ class TestPubSubSockets(unittest.TestCase):
         num_msgs = random.randint(3, 10)
         pub_sock = messaging.pub_sock(sock)
         sub_sock = messaging.sub_sock(sock, conflate=conflate, timeout=None)
+        zmq_sleep()
 
         sent_msgs = []
         for __ in range(num_msgs):
@@ -60,6 +67,7 @@ class TestPubSubSockets(unittest.TestCase):
       timeout = random.randrange(200)
       pub_sock = messaging.pub_sock(sock)
       sub_sock = messaging.sub_sock(sock, timeout=timeout)
+      zmq_sleep()
 
       start_time = time.monotonic()
       recvd = sub_sock.receive()

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -3,11 +3,16 @@ import time
 import random
 import unittest
 
+from cereal import log
 import cereal.messaging as messaging
-from cereal.services import service_list
+
+events = log.Event.schema.union_fields
 
 def random_sock():
-  return random.choice(list(service_list.keys()))
+  return random.choice(events)
+
+def random_socks(num_socks=10):
+  return list(set([random_sock() for _ in range(num_socks)]))
 
 def random_bytes(length=1000):
   return bytes([random.randrange(0xFF) for __ in range(length)])
@@ -61,12 +66,32 @@ class TestPubSubSockets(unittest.TestCase):
       assert recvd is None
 
 class TestSubMaster(unittest.TestCase):
-  pass
+
+  def test_init_state(self):
+    sm = messaging.SubMaster(random_socks())
+    self.assertEquals(sm.frame, -1)
+    self.assertFalse(any(sm.updated.values()))
+    self.assertFalse(any(sm.alive.values()))
+    self.assertTrue(all(t == 0. for t in sm.rcv_time.values()))
+    self.assertTrue(all(f == 0 for f in sm.rcv_frame.values()))
+    self.assertTrue(all(f == 0 for t in sm.logMonoTime.values()))
+
+  def test_update(self):
+    pass
+
+  def test_alive(self):
+    pass
+
+  def test_ignore_alive(self):
+    pass
+
+  def test_valid(self):
+    pass
 
 class TestPubMaster(unittest.TestCase):
 
   def test_send(self):
-    socks = list(set([random_sock() for _ in range(random.randrange(10))]))
+    socks = random_socks()
     pm = messaging.PubMaster(socks)
     sub_socks = {s: messaging.sub_sock(s, timeout=1000) for s in socks}
 

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -19,9 +19,9 @@ def random_socks(num_socks=10):
 def random_bytes(length=1000):
   return bytes([random.randrange(0xFF) for _ in range(length)])
 
-def zmq_sleep():
+def zmq_sleep(t=1):
   if "ZMQ" in os.environ:
-    time.sleep(1)
+    time.sleep(t)
 
 # TODO: test both msgq and zmq
 
@@ -36,7 +36,7 @@ class TestPubSubSockets(unittest.TestCase):
     sock = random_sock()
     pub_sock = messaging.pub_sock(sock)
     sub_sock = messaging.sub_sock(sock, conflate=False, timeout=None)
-    zmq_sleep()
+    zmq_sleep(3)
 
     for _ in range(1000):
       msg = random_bytes()
@@ -68,7 +68,6 @@ class TestPubSubSockets(unittest.TestCase):
 
   def test_receive_timeout(self):
     sock = random_sock()
-    pub_sock = messaging.pub_sock(sock)
     for _ in range(10):
       timeout = random.randrange(200)
       sub_sock = messaging.sub_sock(sock, timeout=timeout)

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -61,12 +61,33 @@ class TestPubSubSockets(unittest.TestCase):
       assert recvd is None
 
 class TestSubMaster(unittest.TestCase):
-
-  def test_update(self):
-    pass
+  pass
 
 class TestPubMaster(unittest.TestCase):
-  pass
+
+  def test_send(self):
+    socks = list(set([random_sock() for _ in range(random.randrange(10))]))
+    pm = messaging.PubMaster(socks)
+    sub_socks = {s: messaging.sub_sock(s, timeout=1000) for s in socks}
+
+    for capnp in [True, False]:
+      for i in range(100):
+        sock = socks[i % len(socks)]
+
+        if capnp:
+          try:
+            msg = messaging.new_message(sock)
+          except:
+            msg = messaging.new_message(sock, random.randrange(50))
+        else:
+          msg = random_bytes()
+
+        pm.send(sock, msg)
+        recvd = sub_socks[sock].receive()
+
+        if capnp:
+          msg = msg.to_bytes()
+        self.assertEqual(msg, recvd)
 
 
 if __name__ == "__main__":

--- a/messaging/tests/test_messaging.py
+++ b/messaging/tests/test_messaging.py
@@ -27,6 +27,11 @@ def zmq_sleep():
 
 class TestPubSubSockets(unittest.TestCase):
 
+  def setUp(self):
+    # ZMQ pub socket takes too long to die
+    # sleep to prevent multiple publishers error between tests
+    zmq_sleep()
+
   def test_pub_sub(self):
     sock = random_sock()
     pub_sock = messaging.pub_sock(sock)
@@ -40,11 +45,11 @@ class TestPubSubSockets(unittest.TestCase):
       self.assertEqual(msg, recvd)
 
   def test_conflate(self):
+    sock = random_sock()
+    pub_sock = messaging.pub_sock(sock)
     for conflate in [True, False]:
       for _ in range(10):
-        sock = random_sock()
         num_msgs = random.randint(3, 10)
-        pub_sock = messaging.pub_sock(sock)
         sub_sock = messaging.sub_sock(sock, conflate=conflate, timeout=None)
         zmq_sleep()
 
@@ -61,11 +66,11 @@ class TestPubSubSockets(unittest.TestCase):
           # TODO: compare actual data
           self.assertEqual(len(recvd_msgs), len(sent_msgs))
 
-  def test_timeout(self):
+  def test_receive_timeout(self):
+    sock = random_sock()
+    pub_sock = messaging.pub_sock(sock)
     for _ in range(10):
-      sock = random_sock()
       timeout = random.randrange(200)
-      pub_sock = messaging.pub_sock(sock)
       sub_sock = messaging.sub_sock(sock, timeout=timeout)
       zmq_sleep()
 

--- a/messaging/tests/test_pub_sub_master.py
+++ b/messaging/tests/test_pub_sub_master.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import numbers
 import random
 import time
@@ -7,7 +6,8 @@ import unittest
 
 from cereal import car
 import cereal.messaging as messaging
-from cereal.messaging.tests.test_messaging import events, random_sock, random_socks, random_bytes
+from cereal.messaging.tests.test_messaging import events, random_sock, random_socks, \
+                                                  random_bytes, zmq_sleep
 
 
 # TODO: this should take any capnp struct and returrn a msg with random populated data
@@ -26,10 +26,6 @@ def assert_carstate(cs1, cs2):
     val1, val2 = getattr(cs1, f), getattr(cs2, f)
     if isinstance(val1, numbers.Number):
       assert val1 == val2, f"{f}: sent '{val1}' vs recvd '{val2}'"
-
-def zmq_sleep():
-  if os.environ["ZMQ"] is not None:
-    time.sleep(1)
 
 
 class TestSubMaster(unittest.TestCase):

--- a/messaging/tests/test_pub_sub_master.py
+++ b/messaging/tests/test_pub_sub_master.py
@@ -30,6 +30,11 @@ def assert_carstate(cs1, cs2):
 
 class TestSubMaster(unittest.TestCase):
 
+  def setUp(self):
+    # ZMQ pub socket takes too long to die
+    # sleep to prevent multiple publishers error between tests
+    zmq_sleep(3)
+
   def test_init(self):
     sm = messaging.SubMaster(events)
     for p in [sm.updated, sm.rcv_time, sm.rcv_frame, sm.alive,

--- a/messaging/tests/test_pub_sub_master.py
+++ b/messaging/tests/test_pub_sub_master.py
@@ -118,7 +118,7 @@ class TestPubMaster(unittest.TestCase):
   def setUp(self):
     # ZMQ pub socket takes too long to die
     # sleep to prevent multiple publishers error between tests
-    zmq_sleep()
+    zmq_sleep(3)
 
   def test_init(self):
     messaging.PubMaster(events)
@@ -137,7 +137,7 @@ class TestPubMaster(unittest.TestCase):
         if capnp:
           try:
             msg = messaging.new_message(sock)
-          except:
+          except Exception:
             msg = messaging.new_message(sock, random.randrange(50))
         else:
           msg = random_bytes()

--- a/messaging/tests/test_pub_sub_master.py
+++ b/messaging/tests/test_pub_sub_master.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import time
+import random
+import unittest
+
+import cereal.messaging as messaging
+from cereal.messaging.tests.test_messaging import events, random_sock, random_socks, random_bytes
+
+class TestSubMaster(unittest.TestCase):
+
+  def test_init(self):
+    messaging.SubMaster(events)
+
+  def test_init_state(self):
+    sm = messaging.SubMaster(random_socks())
+    self.assertEqual(sm.frame, -1)
+    self.assertFalse(any(sm.updated.values()))
+    self.assertFalse(any(sm.alive.values()))
+    self.assertTrue(all(t == 0. for t in sm.rcv_time.values()))
+    self.assertTrue(all(f == 0 for f in sm.rcv_frame.values()))
+    self.assertTrue(all(t == 0 for t in sm.logMonoTime.values()))
+
+  def test_getitem(self):
+    pass
+
+  def test_update(self):
+    pass
+
+  def test_update_timeout(self):
+    pass
+
+  def test_alive(self):
+    pass
+
+  def test_ignore_alive(self):
+    pass
+
+  def test_valid(self):
+    pass
+
+  # SubMaster should always conflate
+  def test_conflate(self):
+    sock = "carState"
+    pub_sock = messaging.pub_sock(sock)
+    sm = messaging.SubMaster([sock,])
+
+    n = 10
+    for i in range(n+1):
+      msg = messaging.new_message(sock)
+      msg.carState.vEgo = i
+      pub_sock.send(msg.to_bytes())
+      time.sleep(0.01)
+    sm.update(2000)
+    self.assertEqual(sm[sock].vEgo, n)
+
+
+class TestPubMaster(unittest.TestCase):
+
+  def test_init(self):
+    messaging.PubMaster(events)
+
+  def test_send(self):
+    socks = random_socks()
+    pm = messaging.PubMaster(socks)
+    sub_socks = {s: messaging.sub_sock(s, timeout=1000) for s in socks}
+
+    # PubMaster accepts either a capnp msg builder or bytes
+    for capnp in [True, False]:
+      for i in range(100):
+        sock = socks[i % len(socks)]
+
+        if capnp:
+          try:
+            msg = messaging.new_message(sock)
+          except:
+            msg = messaging.new_message(sock, random.randrange(50))
+        else:
+          msg = random_bytes()
+
+        pm.send(sock, msg)
+        recvd = sub_socks[sock].receive()
+
+        if capnp:
+          msg = msg.to_bytes()
+        self.assertEqual(msg, recvd)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/messaging/tests/test_pub_sub_master.py
+++ b/messaging/tests/test_pub_sub_master.py
@@ -77,7 +77,6 @@ class TestSubMaster(unittest.TestCase):
 
   def test_update_timeout(self):
     sock = random_sock()
-    pub_sock = messaging.pub_sock(sock)
     sm = messaging.SubMaster([sock,])
     for _ in range(5):
       timeout = random.randrange(1000, 5000)


### PR DESCRIPTION
In preparation of the SubMaster refactor. Once the refactor's done, these python tests should moslty cover the C++ implementation, since all the python stuff will just be a wrapper. The Pub/SubMaster tests should also cover the lower level pub/sub functions, but those should also get their own tests at some point.