### PR TITLE
fix for Ubuntu build

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -49,7 +49,7 @@ if arch == "aarch64":
   shared_lib_shared_lib = [zmq_static, 'm', 'stdc++', "gnustl_shared", "kj", "capnp"]
   env.SharedLibrary('messaging_shared', messaging_objects, LIBS=shared_lib_shared_lib)
 
-env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[messaging_lib, 'zmq'])
+env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[messaging_lib, 'zmq', 'pthread'])
 Depends('messaging/bridge.cc', services_h)
 
 # different target?


### PR DESCRIPTION
I was getting this error when compile cereal from Ubuntu 16.04:
```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
clang++ -o cereal/messaging/bridge -Wl,-rpath=/home/xx979xx/openpilot/external/tensorflow/lib -Wl,-rpath=/home/xx979xx/openpilot/cereal -Wl,-rpath=/home/xx979xx/openpilot/selfdrive/common cereal/messaging/bridge.o -Lphonelibs/snpe/x86_64-linux-clang -Lphonelibs/libyuv/x64/lib -Lexternal/tensorflow/lib -Lcereal -Lselfdrive/common -L/usr/lib -L/usr/local/lib -Lcereal -Lselfdrive/common -Lphonelibs cereal/libmessaging.a -lzmq
/usr/local/lib/libzmq.a(src_libzmq_la-ctx.o): In function `zmq::mutex_t::mutex_t()':
ctx.cpp:(.text._ZN3zmq7mutex_tC2Ev[_ZN3zmq7mutex_tC5Ev]+0x18): undefined reference to `pthread_mutexattr_init'
ctx.cpp:(.text._ZN3zmq7mutex_tC2Ev[_ZN3zmq7mutex_tC5Ev]+0x95): undefined reference to `pthread_mutexattr_settype'
/usr/local/lib/libzmq.a(src_libzmq_la-ctx.o): In function `zmq::mutex_t::~mutex_t()':
ctx.cpp:(.text._ZN3zmq7mutex_tD2Ev[_ZN3zmq7mutex_tD5Ev]+0x8c): undefined reference to `pthread_mutexattr_destroy'
/usr/local/lib/libzmq.a(src_libzmq_la-pipe.o): In function `zmq::mutex_t::try_lock()':
pipe.cpp:(.text._ZN3zmq7mutex_t8try_lockEv[_ZN3zmq7mutex_t8try_lockEv]+0x14): undefined reference to `pthread_mutex_trylock'
/usr/local/lib/libzmq.a(src_libzmq_la-thread.o): In function `thread_routine':
thread.cpp:(.text+0xc5): undefined reference to `pthread_sigmask'
/usr/local/lib/libzmq.a(src_libzmq_la-thread.o): In function `zmq::thread_t::start(void (*)(void*), void*)':
thread.cpp:(.text+0x1dd): undefined reference to `pthread_create'
/usr/local/lib/libzmq.a(src_libzmq_la-thread.o): In function `zmq::thread_t::stop()':
thread.cpp:(.text+0x269): undefined reference to `pthread_join'
/usr/local/lib/libzmq.a(src_libzmq_la-thread.o): In function `zmq::thread_t::applySchedulingParameters()':
thread.cpp:(.text+0x6fd): undefined reference to `pthread_setaffinity_np'
/usr/local/lib/libzmq.a(src_libzmq_la-thread.o): In function `zmq::thread_t::setThreadName(char const*)':
thread.cpp:(.text+0x7bc): undefined reference to `pthread_setname_np'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [cereal/messaging/bridge] Error 1
scons: building terminated because of errors.
```
this fix it for me