### PR TITLE
allow prioritization of services in SubMaster

### DIFF
--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -149,7 +149,7 @@ class SubMaster():
     for s in services:
       if addr is not None:
         p = self.poller
-        if self.block_poller is not None and s in poll:
+        if poll is not None and s in poll:
           p = self.block_poller
         self.sock[s] = sub_sock(s, poller=p, addr=addr, conflate=True)
       self.freq[s] = service_list[s].frequency
@@ -171,7 +171,7 @@ class SubMaster():
     msgs = []
 
     if self.block_poller is not None:
-      for sock in poller.poll(timeout):
+      for sock in self.block_poller.poll(timeout):
         msgs.append(recv_one_or_none(sock))
       timeout = 0 # don't block for second poller
 

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -162,12 +162,12 @@ class SubMaster():
   def __getitem__(self, s: str) -> capnp.lib.capnp._DynamicStructReader:
     return self.data[s]
 
-  def update(self, timeout: int = 1000, service: Optional[str] = None) -> None:
+  def update(self, timeout: int = 1000, wait_for: Optional[str] = None) -> None:
     msgs = []
 
     # blocking receive if service is specified, non-blocking poll for rest of socks
-    if service is not None:
-      msgs.append(recv_one(self.sock[service]))
+    if wait_for is not None:
+      msgs.append(recv_one(self.sock[wait_for]))
       timeout = 0
 
     for sock in self.poller.poll(timeout):

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -128,7 +128,7 @@ class SubMaster():
   def __init__(self, services: List[str], poll: Optional[List[str]] = None,
                ignore_alive: Optional[List[str]] = None, addr:str ="127.0.0.1"):
     self.poller = Poller()
-    self.block_poller = Poller() if poll is not None else None
+    self.priority_poller = Poller() if poll is not None else None
 
     self.frame = -1
     self.updated = {s: False for s in services}
@@ -150,7 +150,7 @@ class SubMaster():
       if addr is not None:
         p = self.poller
         if poll is not None and s in poll:
-          p = self.block_poller
+          p = self.priority_poller
         self.sock[s] = sub_sock(s, poller=p, addr=addr, conflate=True)
       self.freq[s] = service_list[s].frequency
 
@@ -170,8 +170,8 @@ class SubMaster():
   def update(self, timeout: int = 1000) -> None:
     msgs = []
 
-    if self.block_poller is not None:
-      for sock in self.block_poller.poll(timeout):
+    if self.priority_poller is not None:
+      for sock in self.priority_poller.poll(timeout):
         msgs.append(recv_one_or_none(sock))
       timeout = 0 # don't block for second poller
 


### PR DESCRIPTION
This fixes high CPU usage in processes like dmonitoringd which should run at 10hz driven by the driverState packet, but it's main loop runs at 100hz because it subscribes to carState. Blocking on `driverState` reduces dmonitoringd's CPU usage from 6% to 2%.