### PR TITLE
Switch send to using bytes.

### DIFF
--- a/messaging/messaging_pyx.pyx
+++ b/messaging/messaging_pyx.pyx
@@ -140,9 +140,9 @@ cdef class PubSocket:
       else:
         raise MessagingError
 
-  def send(self, string data):
+  def send(self, bytes data):
     length = len(data)
-    r = self.socket.send(<char*>data.c_str(), length)
+    r = self.socket.send(<char*>data, length)
 
     if r != length:
       if errno.errno == errno.EADDRINUSE:

--- a/messaging/tests/test_poller.py
+++ b/messaging/tests/test_poller.py
@@ -97,16 +97,16 @@ class TestPoller(unittest.TestCase):
 
     time.sleep(0.1)  # Slow joiner
 
-    for i in range(100):
-      pub.send(str(i))
+    for i in range(1, 100):
+      pub.send(b'a'*i)
 
     msg_seen = False
-    i = 0
+    i = 1
     while True:
       r = sub.receive(non_blocking=True)
 
       if r is not None:
-        self.assertEqual(str(i), r.decode('utf8'))
+        self.assertEqual(b'a'*i, r)
 
         msg_seen = True
         i += 1


### PR DESCRIPTION
Using string for send introduced a significant conversion overhead for large messages. For instance, for the below example based on demo.py I have observed a 2-4x speedup.
```

import time
import sys
import os
import cereal
from cereal import messaging
from cereal.messaging import Context, SubSocket, PubSocket, Poller
bts = ("a"*1280*720*3*4).encode("ascii")
MSGS = 1000

if __name__ == "__main__":
  c = Context()
  sub_sock = SubSocket()
  pub_sock = PubSocket()

  sub_sock.connect(c, "controlsState")
  pub_sock.connect(c, "controlsState")

  poller = Poller()
  poller.registerSocket(sub_sock)

  t = time.time()
  for i in range(int(MSGS)):
    pub_sock.send(bts)

    for s in poller.poll(100):
      dat = s.receive()

  dt = time.time() - t
  print("%.1f msg/s" % (MSGS / dt))
```