### PR TITLE
Added kfV, kfBP for improved PIcontroller

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -421,6 +421,8 @@ struct CarParams {
     kiBP @2 :List(Float32);
     kiV @3 :List(Float32);
     kf @4 :Float32;
+    kfV @5 :List(Float32);
+    kfBP @6 :List(Float32);
   }
 
   struct LongitudinalPIDTuning {


### PR DESCRIPTION
Xps fork on HKG models used improved PIcontroler (kfV, kfBP instead kf). Steering on whole speed range and especially on lower speed up to 60kmh was much better that master or xx979x. I would like to use it for Kia Niro EV.

https://github.com/commaai/openpilot/discussions/2401#discussioncomment-123170

