### PR TITLE
Added minSpeedCan to CarParams

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -399,6 +399,7 @@ struct CarParams {
   steerRateCost @33 :Float32; # Lateral MPC cost on steering rate
   steerControlType @34 :SteerControlType;
   radarOffCan @35 :Bool; # True when radar objects aren't visible on CAN
+  minSpeedCan @51 :Float32; # Minimum vehicle speed from CAN (below this value drops to 0)
 
   steerActuatorDelay @36 :Float32; # Steering wheel actuator delay in seconds
   openpilotLongitudinalControl @37 :Bool; # is openpilot doing the longitudinal control?


### PR DESCRIPTION
Added minSpeedCan to CarParams to parametrize MIN_CAN_SPEED to car interfaces in OpenPilot.