### PR TITLE
Change InitData.params[].value to take Data instead of Text, part 1 of 2

### DIFF
--- a/log.capnp
+++ b/log.capnp
@@ -42,7 +42,7 @@ struct InitData {
 
   dirty @9 :Bool;
   passive @12 :Bool;
-  params @17 :Map(Text, Text);
+  params @17 :Map(Text, Data);
 
   enum DeviceType {
     unknown @0;


### PR DESCRIPTION
Extend params value to take either Text or Data. This is to allow something like "PandaFirmware" to be processed correctly. According to capnp spec, Text could only be an UTF-8 string, PandaFirmware is evidently a pure binary (as decoded by the web ui):

```
        ( key = "PandaFirmware",
          value = "\x11\x01[\x16|GSe\xd5\x1a+\x94\xff\\f|" ),
```

This is causing logreader.py to fail processing rlog:

```
  root@localhost:/data/openpilot$ python tools/lib/logreader.py /tmp/xxx_2021-01-04--21-40-41--0--rlog
  Traceback (most recent call last):
    File "tools/lib/logreader.py", line 147, in <module>
      print(msg)
    File "capnp/lib/capnp.pyx", line 1091, in capnp.lib.capnp._DynamicStructReader.str
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 30118: invalid continuation byte
```
Not only that, the binary blob also gets truncated at '\0'. The real value is as follows:

```
        ( key = "PandaFirmware",
          value = (
            bin = "\021\001[\026|GSe\325\032+\224\377\\f|\000\241\321\366j\360\247\354E?:\274\205\301\035\241\241T\370X\224\031\367P\257\350*eY\223rt\246\204=\223\301u\207\277\027xE\tn\365?J\234$\032\375\226\300a\215MB\326\342 }\r\366]5\250\236\006\312\000\025\353>Y\v+U\340C\321\017M\231\0307\220\236\303\005\327\'gJ\302Kv\270V\301F8\246\030\206[\344\2239T\003\275" ) ),
```

This is part one of the change, there is also matching change for the openpilot/loggerd to [auto-detect and fill binary params correctly](https://github.com/commaai/openpilot/pull/19693) and also bug in the capnproto to pretty-print [binary data properly in python3](https://github.com/capnproto/capnproto/pull/1143). 