### PR TITLE
MessageBuilder: use stack array for the first segment

### DIFF
--- a/messaging/messaging.hpp
+++ b/messaging/messaging.hpp
@@ -87,9 +87,13 @@ private:
   std::map<std::string, SubMessage *> services_;
 };
 
-class MessageBuilder : public capnp::MallocMessageBuilder {
+struct MessageBuilderSegmentBuffer {
+  alignas(void *) capnp::word buffer[512] = {};
+};
+
+class MessageBuilder : private MessageBuilderSegmentBuffer, public capnp::MallocMessageBuilder {
 public:
-  MessageBuilder() = default;
+  MessageBuilder() : capnp::MallocMessageBuilder(buffer) {}
 
   cereal::Event::Builder initEvent(bool valid = true) {
     cereal::Event::Builder event = initRoot<cereal::Event>();


### PR DESCRIPTION
related document from capnp:
```
explicit MallocMessageBuilder(kj::ArrayPtr<word> firstSegment,   AllocationStrategy allocationStrategy = SUGGESTED_ALLOCATION_STRATEGY);
  // This version always returns the given array for the first segment, and then proceeds with the
  // allocation strategy.  This is useful for optimization when building lots of small messages in
  // a tight loop:  you can reuse the space for the first segment.
  //
  // firstSegment MUST be zero-initialized.  MallocMessageBuilder's destructor will write new zeros
  // over any space that was used so that it can be reused.

```