### PR TITLE
C++ SubMaster: make readers always valid

### DIFF
--- a/messaging/messaging.h
+++ b/messaging/messaging.h
@@ -82,7 +82,7 @@ public:
   bool valid(const char *name) const;
   uint64_t rcv_frame(const char *name) const;
   uint64_t rcv_time(const char *name) const;
-  cereal::Event::Reader &operator[](const char *name);
+  cereal::Event::Reader &operator[](const char *name) const;
 
 private:
   bool all_(const std::initializer_list<const char *> &service_list, bool valid, bool alive);

--- a/messaging/socketmaster.cc
+++ b/messaging/socketmaster.cc
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
+#include <mutex>
 
 #include "services.h"
 #include "messaging.h"
@@ -30,11 +31,18 @@ static inline bool inList(const std::initializer_list<const char *> &list, const
 
 class MessageContext {
 public:
-  MessageContext() { ctx_ = Context::create(); }
+  MessageContext() : ctx_(nullptr) {};
   ~MessageContext() { delete ctx_; }
+  inline Context *context() {
+    std::call_once(init_flag, [=]() { ctx_ = Context::create(); });
+    return ctx_;
+  }
+private:
   Context *ctx_;
+  std::once_flag init_flag;
 };
-MessageContext ctx;
+
+MessageContext message_context;
 
 struct SubMaster::SubMessage {
   std::string name;
@@ -54,7 +62,8 @@ SubMaster::SubMaster(const std::initializer_list<const char *> &service_list, co
   for (auto name : service_list) {
     const service *serv = get_service(name);
     assert(serv != nullptr);
-    SubSocket *socket = SubSocket::create(ctx.ctx_, name, address ? address : "127.0.0.1", true);
+    // assert(ctx.ctx_);
+    SubSocket *socket = SubSocket::create(message_context.context(), name, address ? address : "127.0.0.1", true);
     assert(socket != 0);
     poller_->registerSocket(socket);
     SubMessage *m = new SubMessage{
@@ -63,6 +72,7 @@ SubMaster::SubMaster(const std::initializer_list<const char *> &service_list, co
       .freq = serv->frequency,
       .ignore_alive = inList(ignore_alive, name),
       .allocated_msg_reader = malloc(sizeof(capnp::FlatArrayMessageReader))};
+    m->msg_reader = new (m->allocated_msg_reader) capnp::FlatArrayMessageReader({});
     messages_[socket] = m;
     services_[name] = m;
   }
@@ -82,9 +92,7 @@ void SubMaster::update(int timeout) {
 
     SubMessage *m = messages_.at(s);
 
-    if (m->msg_reader) {
-      m->msg_reader->~FlatArrayMessageReader();
-    }
+    m->msg_reader->~FlatArrayMessageReader();
     m->msg_reader = new (m->allocated_msg_reader) capnp::FlatArrayMessageReader(m->aligned_buf.align(msg));
     delete msg;
     messages.push_back({m->name, m->msg_reader->getRoot<cereal::Event>()});
@@ -162,7 +170,7 @@ uint64_t SubMaster::rcv_time(const char *name) const {
   return services_.at(name)->rcv_time;
 }
 
-cereal::Event::Reader &SubMaster::operator[](const char *name) {
+cereal::Event::Reader &SubMaster::operator[](const char *name) const {
   return services_.at(name)->event;
 };
 
@@ -170,9 +178,7 @@ SubMaster::~SubMaster() {
   delete poller_;
   for (auto &kv : messages_) {
     SubMessage *m = kv.second;
-    if (m->msg_reader) {
-      m->msg_reader->~FlatArrayMessageReader();
-    }
+    m->msg_reader->~FlatArrayMessageReader();
     free(m->allocated_msg_reader);
     delete m->socket;
     delete m;
@@ -182,7 +188,7 @@ SubMaster::~SubMaster() {
 PubMaster::PubMaster(const std::initializer_list<const char *> &service_list) {
   for (auto name : service_list) {
     assert(get_service(name) != nullptr);
-    PubSocket *socket = PubSocket::create(ctx.ctx_, name);
+    PubSocket *socket = PubSocket::create(message_context.context(), name);
     assert(socket);
     sockets_[name] = socket;
   }

--- a/messaging/socketmaster.cc
+++ b/messaging/socketmaster.cc
@@ -62,7 +62,6 @@ SubMaster::SubMaster(const std::initializer_list<const char *> &service_list, co
   for (auto name : service_list) {
     const service *serv = get_service(name);
     assert(serv != nullptr);
-    // assert(ctx.ctx_);
     SubSocket *socket = SubSocket::create(message_context.context(), name, address ? address : "127.0.0.1", true);
     assert(socket != 0);
     poller_->registerSocket(socket);


### PR DESCRIPTION
1. Reader is always valid.
2. Delay initializing MessageContext to prevent it has not been initialized before static SubMaster,which will cause an assert at:
 
https://github.com/commaai/cereal/blob/bab2f2b95e38da4c968efc31369163056e938b30/messaging/impl_msgq.cc#L73