### PR TITLE
Add subaruGen2 and subaruHybrid to CarParams

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -501,6 +501,8 @@ struct CarParams {
     subaruLegacy @22;  # pre-Global platform
     hyundaiLegacy @23;
     hyundaiCommunity @24;
+    subaruGen2 @25;
+    subaruHybrid @26;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
- subaruGen2 is for upcoming Outback/Legacy 2020 port
- subaruHybrid is for upcoming Crosstrek Hybrid 2020 port

Both have slightly different CAN network topology vs Global Platform - some of the messages required by openpilot are new and/or on can1. I will open panda PR for review soon