### PR TITLE
Add stock LKAS/LDW camera detection flag

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -362,6 +362,7 @@ struct CarParams {
   enableGasInterceptor @2 :Bool;
   enableCruise @3 :Bool;
   enableCamera @4 :Bool;
+  enableStockCamera @57 :Bool; # factory LKAS/LDW camera is present
   enableDsu @5 :Bool; # driving support unit
   enableApgs @6 :Bool; # advanced parking guidance system
   enableBsm @56 :Bool; # blind spot monitoring

--- a/car.capnp
+++ b/car.capnp
@@ -362,10 +362,10 @@ struct CarParams {
   enableGasInterceptor @2 :Bool;
   enableCruise @3 :Bool;
   enableCamera @4 :Bool;
-  enableStockCamera @57 :Bool; # factory LKAS/LDW camera is present
   enableDsu @5 :Bool; # driving support unit
   enableApgs @6 :Bool; # advanced parking guidance system
   enableBsm @56 :Bool; # blind spot monitoring
+  hasStockCamera @57 :Bool; # factory LKAS/LDW camera is present
 
   minEnableSpeed @7 :Float32;
   minSteerSpeed @8 :Float32;


### PR DESCRIPTION
For VW MQB and PQ, we can support cars that don't have factory Lane Assist. However, as of commaai/openpilot#20742 (enforcement of checks[] for every signal we look at) we need to check if it's there before trying to proxy its signals.

I propose a new carParams Boolean `enableStockCamera`. This Boolean is intended to operate just like `enableBsm`.

There already exists a Boolean `enableCamera`, but it has a different and deeper meaning in the guts of controlsd.