### PR TITLE
Add support for steering angle sensor precision

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -417,6 +417,7 @@ struct CarParams {
   startingBrakeRate @53 :Float32; # brake_travel/s while releasing on restart
 
   steerActuatorDelay @36 :Float32; # Steering wheel actuator delay in seconds
+  steerAnglePrecision @58 :Float32; # Minimum increment between steering angle signal readings
   openpilotLongitudinalControl @37 :Bool; # is openpilot doing the longitudinal control?
   carVin @38 :Text; # VIN number queried during fingerprinting
   dashcamOnly @41: Bool;


### PR DESCRIPTION
Add `steerAnglePrecision` to CarParams, to set a per-CAR precision available from that car's steering angle sensor. Intended for use as a deadzone for openpilot's PIF lateral control.