### PR TITLE
submaster: revert changes in update

### DIFF
--- a/messaging/messaging.h
+++ b/messaging/messaging.h
@@ -68,8 +68,8 @@ class SubMaster {
 public:
   SubMaster(const std::vector<const char *> &service_list,
             const char *address = nullptr, const std::vector<const char *> &ignore_alive = {});
-  void update(int timeout = 1000);
-  void update_msgs(uint64_t current_time, std::vector<std::pair<std::string, cereal::Event::Reader>> messages);
+  int update(int timeout = 1000);
+  void update_msgs(uint64_t current_time, const std::vector<std::pair<std::string, cereal::Event::Reader>> &messages);
   inline bool allAlive(const std::vector<const char *> &service_list = {}) { return all_(service_list, false, true); }
   inline bool allValid(const std::vector<const char *> &service_list = {}) { return all_(service_list, true, false); }
   inline bool allAliveAndValid(const std::vector<const char *> &service_list = {}) { return all_(service_list, true, true); }


### PR DESCRIPTION
revert  `submaster::update` to the origin version.
I think it's better not to change  `SubMaster::update` for `update_msgs`. it increased complexity and reduced performance. 
