### PR TITLE
Always free ION buffer

### DIFF
--- a/visionipc/visionbuf.h
+++ b/visionipc/visionbuf.h
@@ -49,7 +49,6 @@ class VisionBuf {
 
   // ion
   int handle = 0;
-  bool owner = false;
 
   void allocate(size_t len);
   void import();

--- a/visionipc/visionbuf_ion.cc
+++ b/visionipc/visionbuf_ion.cc
@@ -139,10 +139,7 @@ void VisionBuf::free() {
   munmap(this->addr, this->mmap_len);
   close(this->fd);
 
-  // Free the ION buffer if we also shared it
-  if (this->owner){
-    struct ion_handle_data handle_data = {.handle = this->handle};
-    int ret = ioctl(ion_fd, ION_IOC_FREE, &handle_data);
-    assert(ret == 0);
-  }
+  struct ion_handle_data handle_data = {.handle = this->handle};
+  int ret = ioctl(ion_fd, ION_IOC_FREE, &handle_data);
+  assert(ret == 0);
 }

--- a/visionipc/visionbuf_ion.cc
+++ b/visionipc/visionbuf_ion.cc
@@ -62,7 +62,6 @@ void VisionBuf::allocate(size_t len) {
 
   memset(addr, 0, ion_alloc.len);
 
-  this->owner = true;
   this->len = len;
   this->mmap_len = ion_alloc.len;
   this->addr = addr;
@@ -82,7 +81,6 @@ void VisionBuf::import(){
   err = ioctl(ion_fd, ION_IOC_IMPORT, &fd_data);
   assert(err == 0);
 
-  this->owner = false;
   this->handle = fd_data.handle;
   this->addr = mmap(NULL, this->mmap_len, PROT_READ | PROT_WRITE, MAP_SHARED, this->fd, 0);
   assert(this->addr != MAP_FAILED);

--- a/visionipc/visionipc_server.cc
+++ b/visionipc/visionipc_server.cc
@@ -122,7 +122,6 @@ void VisionIpcServer::listener(){
       bufs[i].buf_cl = 0;
       bufs[i].copy_q = 0;
       bufs[i].handle = 0;
-      bufs[i].owner = false;
 
       bufs[i].server_id = server_id;
     }


### PR DESCRIPTION
https://lwn.net/Articles/480055/ suggest `ION_IOC_FREE` is only necessary after `ION_IOC_SHARE` but this doesn't seem to be the case.