### PR TITLE
Stellantis: Allocate safety mode ID

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -520,6 +520,7 @@ struct CarParams {
     subaruLegacy @22;  # pre-Global platform
     hyundaiLegacy @23;
     hyundaiCommunity @24;
+    stellantis @25;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
Prep for upstream of Tunder's 5th gen RAM 1500 port, which may also support the new 4th gen Jeep Wagoneer and Grand Wagoneer. Messaging and operation looks to be fully distinct from the older Chrysler/FCA platforms.