### PR TITLE
remove androidLog from qlogs

### DIFF
--- a/services.py
+++ b/services.py
@@ -35,7 +35,7 @@ services = {
   "sendcan": (True, 100.),
   "logMessage": (True, 0.),
   "liveCalibration": (True, 4., 4),
-  "androidLog": (True, 0., 1),
+  "androidLog": (True, 0.),
   "carState": (True, 100., 10),
   "carControl": (True, 100., 10),
   "longitudinalPlan": (True, 20., 5),


### PR DESCRIPTION
@pd0wm last thing that relies on this is "LTE emm-detached" detection. do we still need that? maybe we should make it a cloudlog instead?