### PR TITLE
Add STD to the liveParameter message to enable more accurate offline runs

### DIFF
--- a/log.capnp
+++ b/log.capnp
@@ -1300,10 +1300,10 @@ struct LiveParametersData {
   yawRate @7 :Float32;
   posenetSpeed @8 :Float32;
   posenetValid @9 :Bool;
-  angleOffsetFastSTD @10 :Float32;
-  angleOffsetAverageSTD @11 :Float32;
-  stiffnessFactorSTD @12 :Float32;
-  steerRatioSTD @13 :Float32;
+  angleOffsetFastStd @10 :Float32;
+  angleOffsetAverageStd @11 :Float32;
+  stiffnessFactorStd @12 :Float32;
+  steerRatioStd @13 :Float32;
 }
 
 struct LiveMapDataDEPRECATED {

--- a/log.capnp
+++ b/log.capnp
@@ -1300,6 +1300,10 @@ struct LiveParametersData {
   yawRate @7 :Float32;
   posenetSpeed @8 :Float32;
   posenetValid @9 :Bool;
+  angleOffsetFastSTD @10 :Float32;
+  angleOffsetAverageSTD @11 :Float32;
+  stiffnessFactorSTD @12 :Float32;
+  steerRatioSTD @13 :Float32;
 }
 
 struct LiveMapDataDEPRECATED {


### PR DESCRIPTION
Currently when we run offline `parmasd`, the covariances are always initialized to incorrect default values. Due to this, we cannot currently recreate online failures accurately. 

I did not create a new `Measurement` struct like in `liveLocationKalman` as some of the variables are expected in degrees and I wanted to avoid needless conversions.   