### PR TITLE
AlignedBuffer: falls back to a copy if the buffer is not aligned

### DIFF
--- a/messaging/messaging.h
+++ b/messaging/messaging.h
@@ -129,7 +129,10 @@ private:
 class AlignedBuffer {
 public:
   kj::ArrayPtr<const capnp::word> align(const char *data, const size_t size) {
-    words_size = size / sizeof(capnp::word) + 1;
+    bool aligned = reinterpret_cast<uintptr_t>(data) % sizeof(capnp::word) == 0;
+    if (aligned) return {reinterpret_cast<const capnp::word *>(data), size / sizeof(capnp::word)};
+
+    size_t words_size = size / sizeof(capnp::word) + 1;
     if (aligned_buf.size() < words_size) {
       aligned_buf = kj::heapArray<capnp::word>(words_size < 512 ? 512 : words_size);
     }
@@ -141,5 +144,4 @@ public:
   }
 private:
   kj::Array<capnp::word> aligned_buf;
-  size_t words_size;
 };

--- a/messaging/socketmaster.cc
+++ b/messaging/socketmaster.cc
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
+#include <memory>
 #include <mutex>
 
 #include "services.h"
@@ -53,6 +54,7 @@ struct SubMaster::SubMessage {
   void *allocated_msg_reader = nullptr;
   capnp::FlatArrayMessageReader *msg_reader = nullptr;
   AlignedBuffer aligned_buf;
+  std::unique_ptr<Message> message;
   cereal::Event::Reader event;
 };
 
@@ -95,7 +97,7 @@ void SubMaster::update(int timeout) {
     capnp::ReaderOptions options;
     options.traversalLimitInWords = kj::maxValue; // Don't limit
     m->msg_reader = new (m->allocated_msg_reader) capnp::FlatArrayMessageReader(m->aligned_buf.align(msg), options);
-    delete msg;
+    m->message.reset(msg);
     messages.push_back({m->name, m->msg_reader->getRoot<cereal::Event>()});
   }
 


### PR DESCRIPTION
no copy if the buffer is already aligned (just like what pycapnp did)