### PR TITLE
Deprecate active

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -289,7 +289,6 @@ struct RadarData @0x888ad6581cf0aacb {
 struct CarControl {
   # must be true for any actuator commands to work
   enabled @0 :Bool;
-  active @7 :Bool;
 
   # Actuator commands as computed by controlsd
   actuators @6 :Actuators;
@@ -378,6 +377,7 @@ struct CarControl {
   gasDEPRECATED @1 :Float32;
   brakeDEPRECATED @2 :Float32;
   steeringTorqueDEPRECATED @3 :Float32;
+  activeDEPRECATED @7 :Bool;
 }
 
 # ****** car param ******

--- a/log.capnp
+++ b/log.capnp
@@ -547,7 +547,6 @@ struct ControlsState @0x97ff69c53601abf1 {
 
   state @31 :OpenpilotState;
   enabled @19 :Bool;
-  active @36 :Bool;
 
   longControlState @30 :Car.CarControl.Actuators.LongControlState;
   vPid @2 :Float32;
@@ -684,6 +683,7 @@ struct ControlsState @0x97ff69c53601abf1 {
   jerkFactorDEPRECATED @12 :Float32;
   steerOverrideDEPRECATED @20 :Bool;
   steeringAngleDesiredDegDEPRECATED @29 :Float32;
+  activeDEPRECATED @36 :Bool;
 }
 
 struct ModelDataV2 {


### PR DESCRIPTION
We will soon steer in preEnabled, so there's no distinction. openpilot PR: https://github.com/commaai/openpilot/pull/23849