### PR TITLE
FAW: Add safety mode

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -545,6 +545,7 @@ struct CarParams {
     hyundaiLegacy @23;
     hyundaiCommunity @24;
     stellantis @25;
+    faw @26;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
Reserve safety mode identifier for the FAW Hongqi HS5.