### PR TITLE
Add unused attribute to fix scons gcc compile errors

### DIFF
--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -318,10 +318,10 @@ int msgq_msg_ready(msgq_queue_t * q){
     goto start;
   }
 
-  uint32_t read_cycles, read_pointer;
+  uint32_t __attribute__((unused))read_cycles, read_pointer;
   UNPACK64(read_cycles, read_pointer, *q->read_pointers[id]);
 
-  uint32_t write_cycles, write_pointer;
+  uint32_t __attribute__((unused))write_cycles, write_pointer;
   UNPACK64(write_cycles, write_pointer, *q->write_pointer);
 
   // Check if new message is available
@@ -348,7 +348,7 @@ int msgq_msg_recv(msgq_msg_t * msg, msgq_queue_t * q){
   uint32_t read_cycles, read_pointer;
   UNPACK64(read_cycles, read_pointer, *q->read_pointers[id]);
 
-  uint32_t write_cycles, write_pointer;
+  uint32_t __attribute__((unused))write_cycles, write_pointer;
   UNPACK64(write_cycles, write_pointer, *q->write_pointer);
 
   char * p = q->data + read_pointer;


### PR DESCRIPTION
scons -u was failing due to several variables assigned but unused:

![image](https://user-images.githubusercontent.com/29778397/159335128-04aa47be-47b5-496f-8ef9-891c6a3b144a.png)

Applying the `__attribute__((unused))` attribute to these three instances resolves the build errors and allows the repo to compile:

![image](https://user-images.githubusercontent.com/29778397/159335495-06909446-076a-4eb6-a7d9-d7755062c6ca.png)
