### PR TITLE
Add hondaRadarless SafetyModel

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -546,6 +546,7 @@ struct CarParams {
     hyundaiCommunity @24;
     stellantis @25;
     faw @26;
+    hondaRadarless @27;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
Add hondaRadarless SafetyModel for radarless Honda cars like the 2022 Civic. Duplicate of #234 to retest failed check.