### PR TITLE
Fixed cereal bug for simulation in Carla

### DIFF
--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -206,6 +206,7 @@ class SubMaster:
       self.valid[s] = msg.valid
 
       if SIMULATION:
+        self.freq_ok[s] = True
         self.alive[s] = True
 
     if not SIMULATION:


### PR DESCRIPTION
Fixed bug where openpilot doesn't engage because it issue a  **"Low Communication Rate between Processes"** warning on the Carla simulation. 

This behavior happens because the messaging library doesn't set the `self.freq_ok[s]` to True for the `msgs` on the `update_msgs ` method when it is a simulation. 