### PR TITLE
add fuelGaugePercentage to CarState

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -205,6 +205,9 @@ struct CarState {
   leftBlindspot @33 :Bool; # Is there something blocking the left lane change
   rightBlindspot @34 :Bool; # Is there something blocking the right lane change
 
+  # battery or fuel tank
+  fuelGaugePercentage @41 :Float32;
+
   struct WheelSpeeds {
     # optional wheel speeds
     fl @0 :Float32;


### PR DESCRIPTION
Replaces https://github.com/commaai/cereal/pull/290

A Float32 "fuelGaugePercentage" should be easy to understand as the
attribute to use to represent the fuel gauge value as a percentage
from 0.0 to 1.0. It should be generic enough for whatever power
source we call fuel be it gas, electric or something else.