### PR TITLE
add fuelGauge to CarState

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -205,6 +205,8 @@ struct CarState {
   leftBlindspot @33 :Bool; # Is there something blocking the left lane change
   rightBlindspot @34 :Bool; # Is there something blocking the right lane change
 
+  fuelGauge @41 :Float32; # battery or fuel tank level from 0.0 to 1.0
+
   struct WheelSpeeds {
     # optional wheel speeds
     fl @0 :Float32;


### PR DESCRIPTION
A Float32 "fuelGauge" represents the fuel gauge value from
0.0 to 1.0. It should be generic enough for whatever power
source we call fuel be it gas, electric or something else.