### PR TITLE
Add desired curvatures to controlsState

### DIFF
--- a/log.capnp
+++ b/log.capnp
@@ -583,6 +583,10 @@ struct ControlsState @0x97ff69c53601abf1 {
   cumLagMs @15 :Float32;
   canErrorCounter @57 :UInt32;
 
+  # These are the adjusted curvatures that are actually passed to the lateral controllers
+  desiredCurvature @61 :Float32; # Lag adjusted curvature used by lateral controllers
+  desiredCurvatureRate @62 :Float32; # Lag adjusted curvature rate used by lateral controllers
+
   lateralControlState :union {
     indiState @52 :LateralINDIState;
     pidState @53 :LateralPIDState;

--- a/log.capnp
+++ b/log.capnp
@@ -568,6 +568,9 @@ struct ControlsState @0x97ff69c53601abf1 {
   ufAccelCmd @33 :Float32;
   aTarget @35 :Float32;
   curvature @37 :Float32;  # path curvature from vehicle model
+  # These are the adjusted curvatures that are actually passed to the lateral controllers
+  desiredCurvature @61 :Float32; # Lag adjusted curvature used by lateral controllers
+  desiredCurvatureRate @62 :Float32; # Lag adjusted curvature rate used by lateral controllers
   forceDecel @51 :Bool;
 
   # UI alerts
@@ -582,10 +585,6 @@ struct ControlsState @0x97ff69c53601abf1 {
 
   cumLagMs @15 :Float32;
   canErrorCounter @57 :UInt32;
-
-  # These are the adjusted curvatures that are actually passed to the lateral controllers
-  desiredCurvature @61 :Float32; # Lag adjusted curvature used by lateral controllers
-  desiredCurvatureRate @62 :Float32; # Lag adjusted curvature rate used by lateral controllers
 
   lateralControlState :union {
     indiState @52 :LateralINDIState;

--- a/log.capnp
+++ b/log.capnp
@@ -568,9 +568,8 @@ struct ControlsState @0x97ff69c53601abf1 {
   ufAccelCmd @33 :Float32;
   aTarget @35 :Float32;
   curvature @37 :Float32;  # path curvature from vehicle model
-  # These are the adjusted curvatures that are actually passed to the lateral controllers
-  desiredCurvature @61 :Float32; # Lag adjusted curvature used by lateral controllers
-  desiredCurvatureRate @62 :Float32; # Lag adjusted curvature rate used by lateral controllers
+  desiredCurvature @61 :Float32;  # lag adjusted curvatures used by lateral controllers
+  desiredCurvatureRate @62 :Float32;
   forceDecel @51 :Bool;
 
   # UI alerts


### PR DESCRIPTION
Adds the actual curvature and curvature rate that comes out of "get_lag_adjusted_curvature()" and is fed into and used by the lateral controllers. The fields are referred to in controlsd (and the parameter name in update() in the lateral controllers) as desired_curvature and desired_curvature_rate.

Added the fields to ControlsState.

This PR goes together with OP PR: https://github.com/commaai/openpilot/pull/24505

**Background**

While attempting to diagnose unusual tuning behavior in GM Trucks, I had a need to analyze the curvature, and discovered that the curvature actually used by the lateral controllers was not logged anywhere. I added it temporarily, and was surprised to discover that the output of get_lag_adjusted_curvature was in part responsible for the delayed and jerky steering.

