### PR TITLE
Add manumatic gear # to CarState

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -185,6 +185,7 @@ struct CarState {
 
   # gear
   gearShifter @14 :GearShifter;
+  manumaticGear @44 :Int16;  # When gearShifter is manumatic, the selected gear number
 
   # button presses
   buttonEvents @11 :List(ButtonEvent);


### PR DESCRIPTION
For GM vehicles, the manumatic gear includes the selected gear #. Adding to CarState for completeness

Part of implementation for issue https://github.com/commaai/openpilot/issues/24763