### PR TITLE
Panda safety ID list cleanup

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -575,8 +575,8 @@ struct CarParams {
     subaruLegacy @22;  # pre-Global platform
     hyundaiLegacy @23;
     hyundaiCommunity @24;
-    stellantis @25;
-    faw @26;
+    stellantisDEPRECATED @25;  # Consolidated with Chrysler; may be recycled for the next new model
+    hongqi @26;
     body @27;
     hyundaiCanfd @28;
   }


### PR DESCRIPTION
Per DM discussion with @adeebshihadeh, begin renaming FAW to Hongqi in service of the in-progress Hongqi HS5 port. The FAW parent company owns and manufactures many other brands which aren't necessarily going to be Hongqi compatible.

While here, marking the Stellantis safety ID as free for recycling. I added this for an earlier version of the Ram port, but it ended up making sense to consolidate it with Chrysler.