### PR TITLE
Add fields for lateral override

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -17,8 +17,8 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   immediateDisable @6 :Bool;
   preEnable @7 :Bool;
   permanent @8 :Bool; # alerts presented regardless of openpilot state
-  overrideLat @10 :Bool;
-  overrideLong @9 :Bool;
+  overrideLateral @10 :Bool;
+  overrideLongitudinal @9 :Bool;
 
   enum EventName @0xbaa8c5d505f727de {
     canError @0;

--- a/car.capnp
+++ b/car.capnp
@@ -17,7 +17,8 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   immediateDisable @6 :Bool;
   preEnable @7 :Bool;
   permanent @8 :Bool; # alerts presented regardless of openpilot state
-  override @9 :Bool;
+  overrideLat @10 :Bool;
+  overrideLong @9 :Bool;
 
   enum EventName @0xbaa8c5d505f727de {
     canError @0;
@@ -35,6 +36,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     pedalPressed @13;  # exits active state
     pedalPressedPreEnable @73;  # added during pre-enable state for either pedal
     gasPressedOverride @108;  # added when user is pressing gas with no disengage on gas
+    steerOverride @114;
     cruiseDisabled @14;
     speedTooLow @17;
     outOfSpace @18;

--- a/log.capnp
+++ b/log.capnp
@@ -609,7 +609,7 @@ struct ControlsState @0x97ff69c53601abf1 {
     preEnabled @1;
     enabled @2;
     softDisabling @3;
-    overriding @4;  # superset of overriding openpilot with steering or gas
+    overriding @4;  # superset of overriding with steering or accelerator
   }
 
   enum AlertStatus {

--- a/log.capnp
+++ b/log.capnp
@@ -609,7 +609,7 @@ struct ControlsState @0x97ff69c53601abf1 {
     preEnabled @1;
     enabled @2;
     softDisabling @3;
-    overriding @4;
+    overriding @4;  # superset of overriding openpilot with steering or gas
   }
 
   enum AlertStatus {


### PR DESCRIPTION
We can also make a new state, but it's unclear what takes precedence (long or lat overriding)