### PR TITLE
VW MLB: Add safety mode

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -583,7 +583,7 @@ struct CarParams {
     subaruLegacy @22;  # pre-Global platform
     hyundaiLegacy @23;
     hyundaiCommunity @24;
-    stellantisDEPRECATED @25;  # Consolidated with Chrysler; may be recycled for the next new model
+    volkswagenMlb @25;
     hongqi @26;
     body @27;
     hyundaiCanfd @28;


### PR DESCRIPTION
Allocate safety mode for certain last-gen [Volkswagen MLB](https://en.wikipedia.org/wiki/Volkswagen_Group_MLB_platform) that don't have FlexRay.