### PR TITLE
CarFw: add obdMultiplexing

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -612,6 +612,7 @@ struct CarParams {
     brand @6 :Text;
     bus @7 :UInt8;
     logging @8 :Bool;
+    obdMultiplexing @9 :Bool;
   }
 
   enum Ecu {


### PR DESCRIPTION
So we can know without any assumptions whether a request on bus 1 was made to the OBD port or not