### PR TITLE
Ecu: add hvac

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -629,7 +629,6 @@ struct CarParams {
     electricBrakeBooster @15;
     shiftByWire @16;
     adas @19;
-    parking @22;  # ADAS parking ECU
     cornerRadar @21;
     hvac @20;
 

--- a/car.capnp
+++ b/car.capnp
@@ -630,6 +630,8 @@ struct CarParams {
     shiftByWire @16;
     adas @19;
     cornerRadar @21;
+    hvac @20;
+    parking @22;  # ADAS parking ECU
 
     # Toyota only
     dsu @6;
@@ -641,9 +643,6 @@ struct CarParams {
 
     # Chrysler only
     hcp @18;  # Hybrid Control Processor
-
-    # Hyundai only
-    vcu @20;  # Vehicle (Motor) Control Unit
 
     debug @17;
   }

--- a/car.capnp
+++ b/car.capnp
@@ -629,9 +629,9 @@ struct CarParams {
     electricBrakeBooster @15;
     shiftByWire @16;
     adas @19;
+    parking @22;  # ADAS parking ECU
     cornerRadar @21;
     hvac @20;
-    parking @22;  # ADAS parking ECU
 
     # Toyota only
     dsu @6;


### PR DESCRIPTION
replaces never used `vcu` added for hyundai before we switched to the camera with `hvac`