### PR TITLE
Disable cereal fake APIs on macOS

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -24,15 +24,20 @@ env.SharedLibrary('cereal_shared', cereal_objects)
 
 services_h = env.Command(['services.h'], ['services.py'], 'python3 ' + cereal_dir.path + '/services.py > $TARGET')
 
-messaging_objects = env.SharedObject([
+messaging_sources = [
   'messaging/messaging.cc',
-  'messaging/event.cc',
   'messaging/impl_zmq.cc',
   'messaging/impl_msgq.cc',
-  'messaging/impl_fake.cc',
   'messaging/msgq.cc',
   'messaging/socketmaster.cc',
-])
+]
+if arch != "Darwin":
+  env.Append(CPPDEFINES=['CEREAL_FAKE'])
+  messaging_sources.extend([
+    'messaging/event.cc',
+    'messaging/impl_fake.cc',
+  ])
+messaging_objects = env.SharedObject(messaging_sources)
 
 messaging_lib = env.Library('messaging', messaging_objects)
 Depends('messaging/impl_zmq.cc', services_h)

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -1,8 +1,12 @@
 # must be build with scons
-from .messaging_pyx import Context, Poller, SubSocket, PubSocket, SocketEventHandle, toggle_fake_events, set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event  # pylint: disable=no-name-in-module, import-error
-from .messaging_pyx import MultiplePublishersError, MessagingError  # pylint: disable=no-name-in-module, import-error
 import os
 import capnp
+import platform
+
+from .messaging_pyx import Context, Poller, SubSocket, PubSocket # pylint: disable=no-name-in-module, import-error
+from .messaging_pyx import MultiplePublishersError, MessagingError  # pylint: disable=no-name-in-module, import-error
+if platform.system() != "Darwin":
+  from .messaging_pyx import SocketEventHandle, toggle_fake_events, set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event # pylint: disable=no-name-in-module, import-error
 
 from typing import Optional, List, Union
 from collections import deque
@@ -12,11 +16,12 @@ from cereal.services import service_list
 
 assert MultiplePublishersError
 assert MessagingError
-assert toggle_fake_events
-assert set_fake_prefix
-assert get_fake_prefix
-assert delete_fake_prefix
-assert wait_for_one_event
+if platform.system() != "Darwin":
+  assert toggle_fake_events
+  assert set_fake_prefix
+  assert get_fake_prefix
+  assert delete_fake_prefix
+  assert wait_for_one_event
 
 NO_TRAVERSAL_LIMIT = 2**64-1
 AVG_FREQ_HISTORY = 100
@@ -33,7 +38,8 @@ except ImportError:
 context = Context()
 
 
-def fake_event_handle(endpoint: str, identifier: Optional[str] = None, override: bool = True, enable: bool = False) -> SocketEventHandle:
+def fake_event_handle(endpoint: str, identifier: Optional[str] = None, override: bool = True, enable: bool = False):
+  assert platform.system() != "Darwin", "Fake events are not supported on macOS"
   identifier = identifier or get_fake_prefix()
   handle = SocketEventHandle(endpoint, identifier, override)
   if override:

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -3,10 +3,10 @@ import os
 import capnp
 import platform
 
-from .messaging_pyx import Context, Poller, SubSocket, PubSocket # pylint: disable=no-name-in-module, import-error
+from .messaging_pyx import Context, Poller, SubSocket, PubSocket, SocketEventHandle # pylint: disable=no-name-in-module, import-error
 from .messaging_pyx import MultiplePublishersError, MessagingError  # pylint: disable=no-name-in-module, import-error
 if platform.system() != "Darwin":
-  from .messaging_pyx import SocketEventHandle, toggle_fake_events, set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event # pylint: disable=no-name-in-module, import-error
+  from .messaging_pyx import toggle_fake_events, set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event # pylint: disable=no-name-in-module, import-error
 
 from typing import Optional, List, Union
 from collections import deque
@@ -38,7 +38,7 @@ except ImportError:
 context = Context()
 
 
-def fake_event_handle(endpoint: str, identifier: Optional[str] = None, override: bool = True, enable: bool = False):
+def fake_event_handle(endpoint: str, identifier: Optional[str] = None, override: bool = True, enable: bool = False) -> SocketEventHandle:
   assert platform.system() != "Darwin", "Fake events are not supported on macOS"
   identifier = identifier or get_fake_prefix()
   handle = SocketEventHandle(endpoint, identifier, override)

--- a/messaging/messaging.cc
+++ b/messaging/messaging.cc
@@ -105,7 +105,7 @@ Poller * Poller::create(){
   if (messaging_use_fake()) {
     p = new FakePoller();
     return p;
-  } 
+  }
 #endif
   if (messaging_use_zmq()){
     p = new ZMQPoller();

--- a/messaging/messaging.cc
+++ b/messaging/messaging.cc
@@ -53,17 +53,14 @@ SubSocket * SubSocket::create(){
     } else {
       s = new FakeSubSocket<MSGQSubSocket>();
     }
-  } else {
-#endif
-    if (messaging_use_zmq()){
-      s = new ZMQSubSocket();
-    } else {
-      s = new MSGQSubSocket();
-    }
-#ifdef CEREAL_FAKE
+    return s;
   }
 #endif
-
+  if (messaging_use_zmq()){
+    s = new ZMQSubSocket();
+  } else {
+    s = new MSGQSubSocket();
+  }
   return s;
 }
 
@@ -107,16 +104,14 @@ Poller * Poller::create(){
 #ifdef CEREAL_FAKE
   if (messaging_use_fake()) {
     p = new FakePoller();
+    return p;
+  } 
+#endif
+  if (messaging_use_zmq()){
+    p = new ZMQPoller();
   } else {
-#endif
-    if (messaging_use_zmq()){
-      p = new ZMQPoller();
-    } else {
-      p = new MSGQPoller();
-    }
-#ifdef CEREAL_FAKE
+    p = new MSGQPoller();
   }
-#endif
   return p;
 }
 

--- a/messaging/messaging.cc
+++ b/messaging/messaging.cc
@@ -4,7 +4,9 @@
 #include "cereal/messaging/messaging.h"
 #include "cereal/messaging/impl_zmq.h"
 #include "cereal/messaging/impl_msgq.h"
+#ifdef CEREAL_FAKE
 #include "cereal/messaging/impl_fake.h"
+#endif
 
 #ifdef __APPLE__
 const bool MUST_USE_ZMQ = true;
@@ -24,8 +26,12 @@ bool messaging_use_zmq(){
 }
 
 bool messaging_use_fake(){
+#ifdef CEREAL_FAKE
   char* fake_enabled = std::getenv("CEREAL_FAKE");
   return fake_enabled != NULL;
+#else
+  return false;
+#endif
 }
 
 Context * Context::create(){
@@ -40,6 +46,7 @@ Context * Context::create(){
 
 SubSocket * SubSocket::create(){
   SubSocket * s;
+#ifdef CEREAL_FAKE
   if (messaging_use_fake()) {
     if (messaging_use_zmq()) {
       s = new FakeSubSocket<ZMQSubSocket>();
@@ -47,12 +54,15 @@ SubSocket * SubSocket::create(){
       s = new FakeSubSocket<MSGQSubSocket>();
     }
   } else {
+#endif
     if (messaging_use_zmq()){
       s = new ZMQSubSocket();
     } else {
       s = new MSGQSubSocket();
     }
+#ifdef CEREAL_FAKE
   }
+#endif
 
   return s;
 }
@@ -94,15 +104,19 @@ PubSocket * PubSocket::create(Context * context, std::string endpoint, bool chec
 
 Poller * Poller::create(){
   Poller * p;
+#ifdef CEREAL_FAKE
   if (messaging_use_fake()) {
     p = new FakePoller();
   } else {
+#endif
     if (messaging_use_zmq()){
       p = new ZMQPoller();
     } else {
       p = new MSGQPoller();
     }
+#ifdef CEREAL_FAKE
   }
+#endif
   return p;
 }
 

--- a/messaging/messaging_pyx.pyx
+++ b/messaging/messaging_pyx.pyx
@@ -24,90 +24,90 @@ class MessagingError(Exception):
 class MultiplePublishersError(MessagingError):
   pass
 
-
-def toggle_fake_events(bool enabled):
-  cppSocketEventHandle.toggle_fake_events(enabled)
-
-
-def set_fake_prefix(string prefix):
-  cppSocketEventHandle.set_fake_prefix(prefix)
+IF UNAME_SYSNAME != "Darwin":
+  def toggle_fake_events(bool enabled):
+    cppSocketEventHandle.toggle_fake_events(enabled)
 
 
-def get_fake_prefix():
-  return cppSocketEventHandle.fake_prefix()
+  def set_fake_prefix(string prefix):
+    cppSocketEventHandle.set_fake_prefix(prefix)
 
 
-def delete_fake_prefix():
-  cppSocketEventHandle.set_fake_prefix(b"")
+  def get_fake_prefix():
+    return cppSocketEventHandle.fake_prefix()
 
 
-def wait_for_one_event(list events, int timeout=-1):
-  cdef vector[cppEvent] items
-  for event in events:
-    items.push_back(dereference(<cppEvent*><size_t>event.ptr))
-  return cppEvent.wait_for_one(items, timeout)
+  def delete_fake_prefix():
+    cppSocketEventHandle.set_fake_prefix(b"")
 
 
-cdef class Event:
-  cdef cppEvent event;
-
-  def __cinit__(self):
-    pass
-
-  cdef setEvent(self, cppEvent event):
-    self.event = event
-
-  def set(self):
-    self.event.set()
-
-  def clear(self):
-    return self.event.clear()
-
-  def wait(self, int timeout=-1):
-    self.event.wait(timeout)
-
-  def peek(self):
-    return self.event.peek()
-
-  @property
-  def fd(self):
-    return self.event.fd()
-
-  @property
-  def ptr(self):
-    return <size_t><void*>&self.event
+  def wait_for_one_event(list events, int timeout=-1):
+    cdef vector[cppEvent] items
+    for event in events:
+      items.push_back(dereference(<cppEvent*><size_t>event.ptr))
+    return cppEvent.wait_for_one(items, timeout)
 
 
-cdef class SocketEventHandle:
-  cdef cppSocketEventHandle * handle;
+  cdef class Event:
+    cdef cppEvent event;
 
-  def __cinit__(self, string endpoint, string identifier, bool override):
-    self.handle = new cppSocketEventHandle(endpoint, identifier, override)
+    def __cinit__(self):
+      pass
 
-  def __dealloc__(self):
-    del self.handle
+    cdef setEvent(self, cppEvent event):
+      self.event = event
 
-  @property
-  def enabled(self):
-    return self.handle.is_enabled()
+    def set(self):
+      self.event.set()
 
-  @enabled.setter
-  def enabled(self, bool value):
-    self.handle.set_enabled(value)
+    def clear(self):
+      return self.event.clear()
 
-  @property
-  def recv_called_event(self):
-    e = Event()
-    e.setEvent(self.handle.recv_called())
+    def wait(self, int timeout=-1):
+      self.event.wait(timeout)
 
-    return e
+    def peek(self):
+      return self.event.peek()
 
-  @property
-  def recv_ready_event(self):
-    e = Event()
-    e.setEvent(self.handle.recv_ready())
+    @property
+    def fd(self):
+      return self.event.fd()
 
-    return e
+    @property
+    def ptr(self):
+      return <size_t><void*>&self.event
+
+
+  cdef class SocketEventHandle:
+    cdef cppSocketEventHandle * handle;
+
+    def __cinit__(self, string endpoint, string identifier, bool override):
+      self.handle = new cppSocketEventHandle(endpoint, identifier, override)
+
+    def __dealloc__(self):
+      del self.handle
+
+    @property
+    def enabled(self):
+      return self.handle.is_enabled()
+
+    @enabled.setter
+    def enabled(self, bool value):
+      self.handle.set_enabled(value)
+
+    @property
+    def recv_called_event(self):
+      e = Event()
+      e.setEvent(self.handle.recv_called())
+
+      return e
+
+    @property
+    def recv_ready_event(self):
+      e = Event()
+      e.setEvent(self.handle.recv_ready())
+
+      return e
 
 
 cdef class Context:

--- a/messaging/messaging_pyx.pyx
+++ b/messaging/messaging_pyx.pyx
@@ -108,6 +108,9 @@ IF UNAME_SYSNAME != "Darwin":
       e.setEvent(self.handle.recv_ready())
 
       return e
+ELSE:
+  class SocketEventHandle:
+    pass
 
 
 cdef class Context:


### PR DESCRIPTION
macOS lacks `sys/eventfd.h` and some other linux specific which are powering fake sockets. This is using compile-time definitions to remove event.cc and impl_fake.cc from being compiled, and hides python APIs related to that feature.