### PR TITLE
macOS: experimental implementation of fake events using named pipes

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,7 +1,5 @@
 Import('env', 'envCython', 'arch', 'common')
 
-import shutil
-
 cereal_dir = Dir('.')
 gen_dir = Dir('gen')
 messaging_dir = Dir('messaging')
@@ -34,7 +32,7 @@ messaging_objects = env.SharedObject([
   'messaging/socketmaster.cc',
 ])
 
-messaging_lib = env.Library('messaging', messaging_objects)
+messaging_lib = env.Library('messaging', messaging_objects, LIBS=['rt'] if arch != 'Darwin' else [])
 Depends('messaging/impl_zmq.cc', services_h)
 
 env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[messaging_lib, 'zmq', common])

--- a/SConscript
+++ b/SConscript
@@ -32,13 +32,14 @@ messaging_objects = env.SharedObject([
   'messaging/socketmaster.cc',
 ])
 
-messaging_lib = env.Library('messaging', messaging_objects, LIBS=['rt'] if arch != 'Darwin' else [])
+messaging_deps = ['rt'] if arch != 'Darwin' else []
+messaging_lib = env.Library('messaging', messaging_objects, LIBS=messaging_deps)
 Depends('messaging/impl_zmq.cc', services_h)
 
 env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[messaging_lib, 'zmq', common])
 Depends('messaging/bridge.cc', services_h)
 
-envCython.Program('messaging/messaging_pyx.so', 'messaging/messaging_pyx.pyx', LIBS=envCython["LIBS"]+[messaging_lib, "zmq", common])
+envCython.Program('messaging/messaging_pyx.so', 'messaging/messaging_pyx.pyx', LIBS=envCython["LIBS"]+[messaging_lib, "zmq", common]+messaging_deps)
 
 
 # Build Vision IPC
@@ -59,7 +60,7 @@ vipc = env.Library('visionipc', vipc_objects)
 
 
 vipc_frameworks = []
-vipc_libs = envCython["LIBS"] + [vipc, messaging_lib, common, "zmq"]
+vipc_libs = envCython["LIBS"] + [vipc, messaging_lib, common, "zmq"] + messaging_deps
 if arch == "Darwin":
   vipc_frameworks.append('OpenCL')
 else:

--- a/SConscript
+++ b/SConscript
@@ -32,14 +32,13 @@ messaging_objects = env.SharedObject([
   'messaging/socketmaster.cc',
 ])
 
-messaging_deps = ['rt'] if arch != 'Darwin' else []
-messaging_lib = env.Library('messaging', messaging_objects, LIBS=messaging_deps)
+messaging_lib = env.Library('messaging', messaging_objects)
 Depends('messaging/impl_zmq.cc', services_h)
 
 env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[messaging_lib, 'zmq', common])
 Depends('messaging/bridge.cc', services_h)
 
-envCython.Program('messaging/messaging_pyx.so', 'messaging/messaging_pyx.pyx', LIBS=envCython["LIBS"]+[messaging_lib, "zmq", common]+messaging_deps)
+envCython.Program('messaging/messaging_pyx.so', 'messaging/messaging_pyx.pyx', LIBS=envCython["LIBS"]+[messaging_lib, "zmq", common])
 
 
 # Build Vision IPC
@@ -60,7 +59,7 @@ vipc = env.Library('visionipc', vipc_objects)
 
 
 vipc_frameworks = []
-vipc_libs = envCython["LIBS"] + [vipc, messaging_lib, common, "zmq"] + messaging_deps
+vipc_libs = envCython["LIBS"] + [vipc, messaging_lib, common, "zmq"]
 if arch == "Darwin":
   vipc_frameworks.append('OpenCL')
 else:

--- a/messaging/event.cc
+++ b/messaging/event.cc
@@ -16,7 +16,6 @@
 #include <poll.h>
 #include <signal.h>
 #include <fcntl.h>
-#include <sys/posix_shm.h>
 
 #include "cereal/messaging/event.h"
 

--- a/messaging/event.cc
+++ b/messaging/event.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <exception>
 #include <filesystem>
+#include <algorithm>
 
 #ifndef __APPLE__
 #include <sys/eventfd.h>
@@ -32,7 +33,7 @@ void event_state_shm_mmap(std::string endpoint, std::string identifier, char **s
   std::string full_path = "/";
 #else
   std::string full_path = "/dev/shm/";
-#endif 
+#endif
   if (op_prefix) {
     full_path += std::string(op_prefix) + SHM_DELIM;
   }
@@ -47,7 +48,7 @@ void event_state_shm_mmap(std::string endpoint, std::string identifier, char **s
 
 #ifdef __APPLE__
   int shm_fd = shm_open(full_path.c_str(), O_RDWR | O_CREAT, 0664);
-#else 
+#else
   int shm_fd = open(full_path.c_str(), O_RDWR | O_CREAT, 0664);
 #endif
   if (shm_fd < 0) {
@@ -106,7 +107,7 @@ SocketEventHandle::~SocketEventHandle() {
   unlink("/tmp/.recv_called");
   unlink("/tmp/.recv_ready");
   shm_unlink(this->shm_path.c_str());
-#else 
+#else
   unlink(this->shm_path.c_str());
 #endif
 }
@@ -167,7 +168,7 @@ int Event::clear() const {
   uint64_t val = 0;
   // read the eventfd to clear it
 #ifdef __APPLE__
-  while(read(this->event_fd, &val, sizeof(uint64_t)) > 0);
+  while (read(this->event_fd, &val, sizeof(uint64_t)) > 0) {}
 #else
   read(this->event_fd, &val, sizeof(uint64_t));
 #endif

--- a/messaging/event.cc
+++ b/messaging/event.cc
@@ -179,7 +179,7 @@ void Event::wait(int timeout_sec) const {
   throw_if_invalid();
 
   int event_count;
-  struct fd_set fds;
+  fd_set fds;
   FD_ZERO(&fds);
   FD_SET(this->event_fd, &fds);
 
@@ -222,7 +222,7 @@ int Event::fd() const {
 }
 
 int Event::wait_for_one(const std::vector<Event>& events, int timeout_sec) {
-  struct fd_set fds;
+  fd_set fds;
   int max_fd = -1;
   FD_ZERO(&fds);
   for (size_t i = 0; i < events.size(); i++) {

--- a/messaging/event.cc
+++ b/messaging/event.cc
@@ -39,7 +39,7 @@ void event_state_shm_mmap(std::string endpoint, std::string identifier, char **s
 
 #ifdef __APPLE__
   int shm_fd = shm_open(full_path.c_str(), O_RDWR | O_CREAT, 0664);
-#else 
+#else
   int shm_fd = open(full_path.c_str(), O_RDWR | O_CREAT, 0664);
 #endif
   if (shm_fd < 0) {

--- a/messaging/event.h
+++ b/messaging/event.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#define CEREAL_EVENTS_PREFIX std::string("cereal_events")
+#define CEREAL_EVENTS_PREFIX std::string("cev")
 
 void event_state_shm_mmap(std::string endpoint, std::string identifier, char **shm_mem, std::string *shm_path);
 

--- a/messaging/event.h
+++ b/messaging/event.h
@@ -42,6 +42,10 @@ public:
 class SocketEventHandle {
 private:
   std::string shm_path;
+#ifdef __APPLE__
+  std::string fifo_called_path;
+  std::string fifo_ready_path;
+#endif
   EventState* state;
 public:
   SocketEventHandle(std::string endpoint, std::string identifier = "", bool override = true);

--- a/messaging/event.h
+++ b/messaging/event.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#define CEREAL_EVENTS_PREFIX std::string("cev")
+#define CEREAL_EVENTS_PREFIX std::string("cevent")
 
 void event_state_shm_mmap(std::string endpoint, std::string identifier, char **shm_mem, std::string *shm_path);
 

--- a/messaging/messaging.pxd
+++ b/messaging/messaging.pxd
@@ -27,7 +27,7 @@ cdef extern from "cereal/messaging/impl_fake.h":
     @staticmethod
     string fake_prefix()
 
-    SocketEventHandle(string, string, bool)
+    SocketEventHandle(string, string, bool) except +
     bool is_enabled()
     void set_enabled(bool)
     Event recv_called()

--- a/messaging/tests/test_fake.py
+++ b/messaging/tests/test_fake.py
@@ -186,4 +186,5 @@ class TestFakeSockets(unittest.TestCase):
 
 
 if __name__ == "__main__":
+  multiprocessing.set_start_method("fork")
   unittest.main()


### PR DESCRIPTION
* platform specific delimiters for shm filenames
* use `shm_open` and `shm_unlink` instead of open/unlink as shm fs is not directly accessible
* use named pipes with mkfifo instead of eventfd
* replace `ppoll` with equivalent `pselect` as latter is available on both platforms

This provides the implementation of Event API which passes the tests and is shorter than #451, which explicitly disables that functionality.