### PR TITLE
carState: non-critical car faulted field

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -116,7 +116,6 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     resumeBlocked @113;
     steerTimeLimit @115;
     vehicleSensorsInvalid @116;
-    carFaultedNonCritical @118;
 
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
@@ -167,7 +166,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-  
+
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0

--- a/car.capnp
+++ b/car.capnp
@@ -116,7 +116,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     resumeBlocked @113;
     steerTimeLimit @115;
     vehicleSensorsInvalid @116;
-    carFaulted @118;
+    carFaultedNonCritical @118;
 
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
@@ -190,7 +190,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  carFaulted @47 :Bool;
+  carFaultedNonCritical @47 :Bool;
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -189,7 +189,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  carFaultedNonCritical @47 :Bool;  # some ECU is faulted, but car remains controllable
+  carFaultedNonCritical @47 :Bool;  # an ECU is faulted, but car remains controllable
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -189,7 +189,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  carFaultedNonCritical @47 :Bool;  # an ECU is faulted, but car remains controllable
+  carFaultedNonCritical @47 :Bool;  # some ECU is faulted, but car remains controllable
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -189,7 +189,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  carFaultedNonCritical @47 :Bool;
+  carFaultedNonCritical @47 :Bool;  # some ECU is faulted, but car remains controllable
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -116,7 +116,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     resumeBlocked @113;
     steerTimeLimit @115;
     vehicleSensorsInvalid @116;
-    adasFaulted @116;
+    adasFaulted @118;
 
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
@@ -167,7 +167,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-  
+
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0
@@ -190,7 +190,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  adasFaulted @42 :Bool;
+  adasFaulted @47 :Bool;
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -167,7 +167,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-
+  
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0

--- a/car.capnp
+++ b/car.capnp
@@ -116,6 +116,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     resumeBlocked @113;
     steerTimeLimit @115;
     vehicleSensorsInvalid @116;
+    adasFaulted @116;
 
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
@@ -189,6 +190,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
+  adasFaulted @42 :Bool;
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -116,7 +116,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     resumeBlocked @113;
     steerTimeLimit @115;
     vehicleSensorsInvalid @116;
-    adasFaulted @118;
+    carFaulted @118;
 
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
@@ -190,7 +190,7 @@ struct CarState {
   stockFcw @31 :Bool;
   espDisabled @32 :Bool;
   accFaulted @42 :Bool;
-  adasFaulted @47 :Bool;
+  carFaulted @47 :Bool;
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/car.capnp
+++ b/car.capnp
@@ -166,7 +166,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-
+  
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0


### PR DESCRIPTION
true if some ECU is faulted, but car remains controllable (for ex. camera faulted, but we are controlling both lat and long)

also for ex. camera faulted and we are not controlling long, that would be CRITICAL (accFaulted)