### PR TITLE
Deprecate brakeUnavailable event

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -23,7 +23,6 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   enum EventName @0xbaa8c5d505f727de {
     canError @0;
     steerUnavailable @1;
-    brakeUnavailable @2;
     wrongGear @4;
     doorOpen @5;
     seatbeltNotLatched @6;
@@ -140,6 +139,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     startupOneplusDEPRECATED @82;
     startupFuzzyFingerprintDEPRECATED @97;
     noTargetDEPRECATED @25;
+    brakeUnavailableDEPRECATED @2;
   }
 }
 
@@ -166,7 +166,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-  
+
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0

--- a/car.capnp
+++ b/car.capnp
@@ -166,7 +166,7 @@ struct CarState {
   # gas pedal, 0.0-1.0
   gas @3 :Float32;        # this is user pedal only
   gasPressed @4 :Bool;    # this is user pedal only
-
+  
   engineRpm @46 :Float32;
 
   # brake pedal, 0.0-1.0


### PR DESCRIPTION
We can, in the future, revive this to distinguish ABS module/brake controller related faults and PCM/accelerator control faults in the qlogs, but for now, Honda was the only make using this (for both brake and normal PCM ACC faults), so remove.