### PR TITLE
connect: add error messages when Socket connect fails

### DIFF
--- a/messaging/messaging.cc
+++ b/messaging/messaging.cc
@@ -65,7 +65,9 @@ SubSocket * SubSocket::create(Context * context, std::string endpoint, std::stri
     return s;
   } else {
     delete s;
-    return NULL;
+    throw std::runtime_error(
+      "Failed to connect to " + endpoint + ": " + std::string(strerror(errno))
+    );
   }
 }
 
@@ -88,7 +90,9 @@ PubSocket * PubSocket::create(Context * context, std::string endpoint, bool chec
     return s;
   } else {
     delete s;
-    return NULL;
+    throw std::runtime_error(
+      "Failed to connect to " + endpoint + ": " + std::string(strerror(errno))
+    );
   }
 }
 

--- a/messaging/messaging.cc
+++ b/messaging/messaging.cc
@@ -64,10 +64,10 @@ SubSocket * SubSocket::create(Context * context, std::string endpoint, std::stri
   if (r == 0) {
     return s;
   } else {
+    std::cerr << "Error, failed to connect SubSocket to " << endpoint << ": " << strerror(errno) << std::endl;
+
     delete s;
-    throw std::runtime_error(
-      "Failed to connect to " + endpoint + ": " + std::string(strerror(errno))
-    );
+    return nullptr;
   }
 }
 
@@ -89,10 +89,10 @@ PubSocket * PubSocket::create(Context * context, std::string endpoint, bool chec
   if (r == 0) {
     return s;
   } else {
+    std::cerr << "Error, failed to bind PubSocket to " << endpoint << ": " << strerror(errno) << std::endl;
+
     delete s;
-    throw std::runtime_error(
-      "Failed to connect to " + endpoint + ": " + std::string(strerror(errno))
-    );
+    return nullptr;
   }
 }
 

--- a/messaging/messaging_pyx.pyx
+++ b/messaging/messaging_pyx.pyx
@@ -6,6 +6,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp cimport bool
 from libc cimport errno
+from libc.string cimport strerror
 from cython.operator import dereference
 
 
@@ -18,7 +19,10 @@ from .messaging cimport Event as cppEvent, SocketEventHandle as cppSocketEventHa
 
 
 class MessagingError(Exception):
-  pass
+  def __init__(self, endpoint=None):
+    suffix = "with {endpoint}" if endpoint else ""
+    message = f"Messaging failure {suffix}: {strerror(errno.errno)}"
+    super().__init__(self.message)
 
 
 class MultiplePublishersError(MessagingError):
@@ -184,9 +188,9 @@ cdef class SubSocket:
 
     if r != 0:
       if errno.errno == errno.EADDRINUSE:
-        raise MultiplePublishersError
+        raise MultiplePublishersError(endpoint)
       else:
-        raise MessagingError
+        raise MessagingError(endpoint)
 
   def setTimeout(self, int timeout):
     self.socket.setTimeout(timeout)
@@ -225,9 +229,9 @@ cdef class PubSocket:
 
     if r != 0:
       if errno.errno == errno.EADDRINUSE:
-        raise MultiplePublishersError
+        raise MultiplePublishersError(endpoint)
       else:
-        raise MessagingError
+        raise MessagingError(endpoint)
 
   def send(self, bytes data):
     length = len(data)

--- a/messaging/messaging_pyx.pyx
+++ b/messaging/messaging_pyx.pyx
@@ -22,7 +22,7 @@ class MessagingError(Exception):
   def __init__(self, endpoint=None):
     suffix = "with {endpoint}" if endpoint else ""
     message = f"Messaging failure {suffix}: {strerror(errno.errno)}"
-    super().__init__(self.message)
+    super().__init__(message)
 
 
 class MultiplePublishersError(MessagingError):


### PR DESCRIPTION
This aims to make socket create/connect failures more descriptive. Currently the c++ op services and Pub/SubMasters usually fail with assertion or segfault, which does not provide any information about the reason (which may be trivial to solve).

This happens very often with ZMQ, when some other service on your local machine is using some 80XX port.

This is also alignment with cython wrappers which do throw an error when connect fails. 