### PR TITLE
VisionIpcServer: unlink path after closing socket

### DIFF
--- a/visionipc/visionipc_server.cc
+++ b/visionipc/visionipc_server.cc
@@ -154,6 +154,7 @@ void VisionIpcServer::listener(){
 
   std::cout << "Stopping listener for: " << name << std::endl;
   close(sock);
+  unlink(path.c_str());
 }
 
 


### PR DESCRIPTION
issue: got some strange strange behavior when testing CameraView. For example, after vipc_server exits, the call to ipc_connect or ipc_sendrecv_with_fds  may be blocked and unable to return， prevents the vipcThread from running properly.

fixed: use unlink() to delete the file created at bind() for AF_UNIX  socket:  https://www.man7.org/linux/man-pages/man2/bind.2.html
