### PR TITLE
refactor msgq_poll to return immediately on new messages.

### DIFF
--- a/messaging/impl_msgq.cc
+++ b/messaging/impl_msgq.cc
@@ -9,13 +9,6 @@
 #include "cereal/messaging/impl_msgq.h"
 
 
-volatile sig_atomic_t msgq_do_exit = 0;
-
-void sig_handler(int signal) {
-  assert(signal == SIGINT || signal == SIGTERM);
-  msgq_do_exit = 1;
-}
-
 static bool service_exists(std::string path){
   for (const auto& it : services) {
     if (it.name == path) {
@@ -84,61 +77,24 @@ int MSGQSubSocket::connect(Context *context, std::string endpoint, std::string a
   return 0;
 }
 
-
-Message * MSGQSubSocket::receive(bool non_blocking){
-  msgq_do_exit = 0;
-
-  void (*prev_handler_sigint)(int);
-  void (*prev_handler_sigterm)(int);
-  if (!non_blocking){
-    prev_handler_sigint = std::signal(SIGINT, sig_handler);
-    prev_handler_sigterm = std::signal(SIGTERM, sig_handler);
-  }
-
+Message *MSGQSubSocket::receive(bool non_blocking) {
   msgq_msg_t msg;
-
-  MSGQMessage *r = NULL;
-
-  int rc = msgq_msg_recv(&msg, q);
-
-  // Hack to implement blocking read with a poller. Don't use this
-  while (!non_blocking && rc == 0 && msgq_do_exit == 0){
-    msgq_pollitem_t items[1];
-    items[0].q = q;
-
-    int t = (timeout != -1) ? timeout : 100;
-
-    int n = msgq_poll(items, 1, t);
+  int rc = 0;
+  if (non_blocking) {
     rc = msgq_msg_recv(&msg, q);
-
-    // The poll indicated a message was ready, but the receive failed. Try again
-    if (n == 1 && rc == 0){
-      continue;
-    }
-
-    if (timeout != -1){
-      break;
+  } else {
+    msgq_pollitem_t pollitem = {.q = q};
+    if (msgq_poll(&pollitem, 1, timeout) == 1) {
+      rc = msgq_msg_recv(&msg, q);
     }
   }
 
-
-  if (!non_blocking){
-    std::signal(SIGINT, prev_handler_sigint);
-    std::signal(SIGTERM, prev_handler_sigterm);
+  MSGQMessage *r = nullptr;
+  if (rc > 0) {
+    r = new MSGQMessage;
+    r->takeOwnership(msg.data, msg.size);
   }
-
-  errno = msgq_do_exit ? EINTR : 0;
-
-  if (rc > 0){
-    if (msgq_do_exit){
-      msgq_msg_close(&msg); // Free unused message on exit
-    } else {
-      r = new MSGQMessage;
-      r->takeOwnership(msg.data, msg.size);
-    }
-  }
-
-  return (Message*)r;
+  return r;
 }
 
 void MSGQSubSocket::setTimeout(int t){


### PR DESCRIPTION
issue:  When there is no new message, the `msgq_poll` and `MSGQSubSocket::receive`  will sleep for a fixed timeout  before checking for new messages again.  this makes them unable to  provide a mechanism to synchronous events multiplex like zmq_poll/ linux poll.

fixed: use sigtimedwait  to wake up "msgq_poll" when there is a new message.


