### PR TITLE
CarParams.Ecu: rename hcp to hybrid

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -628,7 +628,7 @@ struct CarParams {
     engine @4;
     unknown @5;
     transmission @8; # Transmission Control Module
-    hybrid @18;  # hybrid control unit. e.g. Chrysler's Hybrid Control Processor, Toyota's hybrid control computer
+    hybrid @18; # hybrid control unit e.g. Chrysler's HCP, Toyota's hybrid control computer, Honda's IMA Control Unit
     srs @9; # airbag
     gateway @10; # can gateway
     hud @11; # heads up display

--- a/car.capnp
+++ b/car.capnp
@@ -628,7 +628,7 @@ struct CarParams {
     engine @4;
     unknown @5;
     transmission @8; # Transmission Control Module
-    hybrid @18; # hybrid control unit e.g. Chrysler's HCP, Honda's IMA Control Unit, Toyota's hybrid control computer
+    hybrid @18; # hybrid control unit, e.g. Chrysler's HCP, Honda's IMA Control Unit, Toyota's hybrid control computer
     srs @9; # airbag
     gateway @10; # can gateway
     hud @11; # heads up display

--- a/car.capnp
+++ b/car.capnp
@@ -628,7 +628,7 @@ struct CarParams {
     engine @4;
     unknown @5;
     transmission @8; # Transmission Control Module
-    hybrid @18; # hybrid control unit e.g. Chrysler's HCP, Toyota's hybrid control computer, Honda's IMA Control Unit
+    hybrid @18; # hybrid control unit e.g. Chrysler's HCP, Honda's IMA Control Unit, Toyota's hybrid control computer
     srs @9; # airbag
     gateway @10; # can gateway
     hud @11; # heads up display

--- a/car.capnp
+++ b/car.capnp
@@ -628,6 +628,7 @@ struct CarParams {
     engine @4;
     unknown @5;
     transmission @8; # Transmission Control Module
+    hybrid @18;  # hybrid control unit. e.g. Chrysler's Hybrid Control Processor, Toyota's hybrid control computer
     srs @9; # airbag
     gateway @10; # can gateway
     hud @11; # heads up display
@@ -640,7 +641,6 @@ struct CarParams {
     parkingAdas @7;  # parking assist system ECU, e.g. Toyota's IPAS, Hyundai's RSPA, etc.
     epb @22;  # electronic parking brake
     telematics @23;
-    hcu @18;  # hybrid control unit. e.g. Chrysler's Hybrid Control Processor, Toyota's hybrid control computer
 
     # Toyota only
     dsu @6;

--- a/car.capnp
+++ b/car.capnp
@@ -640,6 +640,7 @@ struct CarParams {
     parkingAdas @7;  # parking assist system ECU, e.g. Toyota's IPAS, Hyundai's RSPA, etc.
     epb @22;  # electronic parking brake
     telematics @23;
+    hcu @18;  # hybrid control unit. e.g. Chrysler's Hybrid Control Processor, Toyota's hybrid control computer
 
     # Toyota only
     dsu @6;
@@ -647,9 +648,6 @@ struct CarParams {
     # Honda only
     vsa @13; # Vehicle Stability Assist
     programmedFuelInjection @14;
-
-    # Chrysler only
-    hcp @18;  # Hybrid Control Processor
 
     debug @17;
   }


### PR DESCRIPTION
Originally added for: https://github.com/commaai/openpilot/pull/25606. This makes it a generic Ecu we can use for different brands, specifically for Toyota here: https://github.com/commaai/openpilot/pull/28628.

Needs openpilot PR: https://github.com/commaai/openpilot/pull/28629

- Some info about the Chrysler HCP: https://www.allpar.com/threads/deep-inside-the-chrysler-pacifica-hybrid-system.230025/

  Summary: HCP has (is part of) an inverter and controls flow of energy and the motors.
- Some info about Toyota's hybrid system: https://en.wikipedia.org/wiki/Hybrid_Synergy_Drive

  Summary: Toyota also has a computer/ECU that manages the power flow between engine, MG2 (motor generator), and battery.
- Honda is similar with the [Integrated Motor Assist](https://en.wikipedia.org/wiki/Integrated_Motor_Assist).