### PR TITLE
VisionIpcClient: remove init_msgq

### DIFF
--- a/visionipc/visionipc_client.h
+++ b/visionipc/visionipc_client.h
@@ -19,8 +19,6 @@ private:
   cl_device_id device_id = nullptr;
   cl_context ctx = nullptr;
 
-  void init_msgq(bool conflate);
-
 public:
   bool connected = false;
   VisionStreamType type;


### PR DESCRIPTION
 remove obsolete decl `init_msgq` without definition.