### PR TITLE
add secOCKey to carParams

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -499,6 +499,8 @@ struct CarParams {
 
   wheelSpeedFactor @63 :Float32; # Multiplier on wheels speeds to computer actual speeds
 
+  secOCKey @74 :Data;
+
   struct SafetyConfig {
     safetyModel @0 :SafetyModel;
     safetyParam @3 :UInt16;


### PR DESCRIPTION
Probably useful to ensure routes can be used in process replay. Can also be fetched from initData if you don't want it in the carParams.