### PR TITLE
deprecate curvature steer control type

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -601,7 +601,8 @@ struct CarParams {
   enum SteerControlType {
     torque @0;
     angle @1;
-    curvature @2;
+
+    curvatureDEPRECATED @2;
   }
 
   enum TransmissionType {

--- a/log.capnp
+++ b/log.capnp
@@ -713,8 +713,8 @@ struct ControlsState @0x97ff69c53601abf1 {
     angleState @58 :LateralAngleState;
     debugState @59 :LateralDebugState;
     torqueState @60 :LateralTorqueState;
-    curvatureState @65 :LateralCurvatureState;
 
+    curvatureStateDEPRECATED @65 :LateralCurvatureState;
     lqrStateDEPRECATED @55 :LateralLQRState;
   }
 


### PR DESCRIPTION
Wasn't used after merging