### PR TITLE
Revert "move vipc to a prefix folder"

### DIFF
--- a/visionipc/visionipc_server.cc
+++ b/visionipc/visionipc_server.cc
@@ -25,7 +25,7 @@ std::string get_endpoint_name(std::string name, VisionStreamType type){
 std::string get_ipc_path(const std::string& name) {
   std::string path = "/tmp/";
   if (char* prefix = std::getenv("OPENPILOT_PREFIX")) {
-    path += std::string(prefix) + "/";
+    path += std::string(prefix) + "_";
   }
   return path + "visionipc_" + name;
 }


### PR DESCRIPTION
Reverts commaai/cereal#580

this breaks cabana as is