### PR TITLE
msgq: connect immediately

### DIFF
--- a/messaging/impl_msgq.cc
+++ b/messaging/impl_msgq.cc
@@ -155,6 +155,7 @@ int MSGQPubSocket::connect(Context *context, std::string endpoint, bool check_en
   }
 
   q = new msgq_queue_t;
+  printf("endpoint: %s\n", endpoint.c_str());
   int r = msgq_new_queue(q, endpoint.c_str(), DEFAULT_SEGMENT_SIZE);
   if (r != 0){
     return r;

--- a/messaging/impl_msgq.cc
+++ b/messaging/impl_msgq.cc
@@ -155,7 +155,6 @@ int MSGQPubSocket::connect(Context *context, std::string endpoint, bool check_en
   }
 
   q = new msgq_queue_t;
-  printf("endpoint: %s\n", endpoint.c_str());
   int r = msgq_new_queue(q, endpoint.c_str(), DEFAULT_SEGMENT_SIZE);
   if (r != 0){
     return r;

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -155,6 +155,13 @@ void msgq_init_publisher(msgq_queue_t * q) {
   //std::cout << "Starting publisher" << std::endl;
   uint64_t uid = msgq_get_uid();
 
+  // Notify readers to connect
+  uint64_t num_readers = *q->num_readers;
+  for (uint64_t i = 0; i < num_readers; i++){
+    uint64_t reader_uid = *q->read_uids[i];
+    thread_signal(reader_uid & 0xFFFFFFFF);
+  }
+
   *q->write_uid = uid;
   *q->num_readers = 0;
 
@@ -164,15 +171,6 @@ void msgq_init_publisher(msgq_queue_t * q) {
   }
 
   q->write_uid_local = uid;
-
-   // Notify readers new
-//  uint64_t num_readers = *q->num_readers;
-//  std::cout << "Notifying " << num_readers << " readers" << std::endl;
-//  for (uint64_t i = 0; i < num_readers; i++){
-////    std::cout << "notifying reader: " << i << std::endl;
-//    uint64_t reader_uid = *q->read_uids[i];
-//    thread_signal(reader_uid & 0xFFFFFFFF);
-//  }
 }
 
 void msgq_init_subscriber(msgq_queue_t * q) {

--- a/messaging/msgq.cc
+++ b/messaging/msgq.cc
@@ -465,13 +465,10 @@ int msgq_poll(msgq_pollitem_t * items, size_t nitems, int timeout){
 
 bool msgq_all_readers_updated(msgq_queue_t *q) {
   uint64_t num_readers = *q->num_readers;
-//  std::cout << "all_readers_updated: " << num_readers << std::endl;
   for (uint64_t i = 0; i < num_readers; i++) {
     if (*q->read_valids[i] && *q->write_pointer != *q->read_pointers[i]) {
-//      std::cout << "returning false";
       return false;
     }
   }
-//  std::cout << "here";
   return num_readers > 0;
 }


### PR DESCRIPTION
When the publisher is created, it calls `msgq_init_publisher` which resets the reader count. If you send data (in `msgq_msg_send`) before the subcriber connects, you will have no readers to signal to here:

https://github.com/commaai/cereal/blob/bd31b25aacc5b39f36cedcb0dabd05db471da59f/messaging/msgq.cc#L295-L299

This PR finds all current readers and sends a SIGUSR2 signal. Verified that the subscriber polling doesn't finish early when a publisher is created.

---

<details><summary>Subscriber</summary>

```python
from cereal.messaging import SubMaster, PubMaster, new_message, sub_sock
from cereal import log
import time

sock = sub_sock('sendcan')
sock.setTimeout(100)

t = time.time()
while True:
  print('recv', sock.receive())
  print(time.time() - t)
  print()
```

</details>

<details><summary>Publisher</summary>

```
from cereal.messaging import PubMaster, new_message
from cereal import log
import time

times = []

for _ in range(1000):
  pm = PubMaster(['sendcan'])
  t = time.monotonic()
  while 1:
    if pm.sock['sendcan'].all_readers_updated():
      times.append(time.monotonic() - t)
      break

print(times)
print(sum(times) / len(times))
```

</details>

Time for all readers to connect (should be half of subscriber dt on average):

```python
0.05434682522984804 mean, 0.049833057644082523 std
```

After change: 

```python
2.469095983542502e-06 mean, 7.680831147408531e-07 std
```