### PR TITLE
Ecu: add vcu

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -635,6 +635,7 @@ struct CarParams {
     unknown @5;
     transmission @8; # Transmission Control Module
     hybrid @18; # hybrid control unit, e.g. Chrysler's HCP, Honda's IMA Control Unit, Toyota's hybrid control computer
+    vcu @25;  # Vehicle (Motor) Control Unit (on electric cars)
     srs @9; # airbag
     gateway @10; # can gateway
     hud @11; # heads up display


### PR DESCRIPTION
Some context about this ECU: https://github.com/commaai/openpilot/pull/25607#issuecomment-1239969101

On Hyundai it's 0x7e2 (not useful since it's not on OBD), and on the Nissan Leaf, it's 0x797 with an rx offset of 3, and has the VIN on bus 0.

Originally added here but replaced since we didn't use it: https://github.com/commaai/cereal/pull/348