### PR TITLE
Test docker cache on commaai/cereal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ env:
   BUILD: docker buildx build --pull --load --cache-to type=inline --cache-from type=registry,ref=$DOCKER_REGISTRY/cereal:latest -t cereal -f Dockerfile .
   PYTHONWARNINGS: error
 
+
 jobs:
   build:
     name: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ env:
   RUN: docker run -e PYTHONWARNINGS=error --shm-size 1G --name cereal cereal /bin/sh -c
   RUN_NAMED: docker run -e PYTHONWARNINGS=error --shm-size 1G --rm cereal /bin/sh -c
   CI_RUN: docker run -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID --rm cerealci /bin/bash -c
-  BUILD: docker buildx build --pull --load --cache-to type=inline --cache-from $DOCKER_REGISTRY/cereal:latest -t cereal -f Dockerfile .
+  BUILD: docker buildx build --pull --load --cache-to type=inline --cache-from type=registry,ref=$DOCKER_REGISTRY/cereal:latest -t cereal -f Dockerfile .
   PYTHONWARNINGS: error
 
 jobs:


### PR DESCRIPTION
need to see if this pull cache in commaai cereal repo

cache pulled here:
https://github.com/bongbui321/cereal/actions/runs/8071258104
https://github.com/bongbui321/cereal/actions/runs/8071258104
https://github.com/bongbui321/cereal/actions/runs/8071308271
https://github.com/bongbui321/cereal/actions/runs/8071297568

