### PR TITLE
PSA: add safety mode

### DIFF
--- a/car.capnp
+++ b/car.capnp
@@ -603,6 +603,7 @@ struct CarParams {
     hyundaiCanfd @28;
     volkswagenMqbEvo @29;
     chryslerCusw @30;
+    psa @31;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
I'm in the process of reverse engineering the Vauxhall/Opel Corsa F, and it looks as though the LKAS hardware is shared between Citroën/Peugot/DS/Opel. Although PSA Group is now merged with Stellantis, I think this is the best way to group these potential platforms in openpilot.

The platfrom is called [CMP (or EMP1)](https://en.wikipedia.org/wiki/Common_Modular_Platform#CMP).

![](https://media.discordapp.net/attachments/943275077137498112/1203440337260118047/ABLVV84Ypo_LcfUsmmeMh2XsaeIpsTpOD5yaPR8luKvC6k9FmxehTYMrbihaU4UW51fSPRWWBUVR9xeDw-iIyNtSZzs7kP59Wypp8oo9ohybfo6Kj8yOEMhbq-d4aiZQVMHlFY8pUvlUwBGLFNTysGcBCPY9MaJkw6DhgWct_10zVsCRy4oTpn4wlraNqZWdefPJwm_BX4g8FPnnEMPc0VNQY2vZVaEnnMCmKISM7LFc3eZe62fWmuKK0LdcmES1GL480cucM8mM2gMaCTBtGEqbP0xeMDOYWRW6u7T20dD66c6C815umjgHepBkmtUcfQLfo9jkGEZspYQrvczBrThsxG8Kl27GAf690lSJlmDLG_64Rl18KzGrK-EtDTygMx4vawgtHg52sVwsh7ptQTbD7EH3jGXZNQmEq7_c2gfusg3Op2iSkDz5MDyXBqVczS984KDYjab__50bJqmclQIIiZDJK6L6VBF7U4SohxXyuU-4RdmjEn2jklGa..png?ex=65f60427&is=65e38f27&hm=046f96d46d336b3bda96bec943dacd1a64582a37e171603c71c83cbb98ccd72c&=&format=webp&width=400&height=531)