### PR TITLE
add bootlogId to `initData`

### DIFF
--- a/log.capnp
+++ b/log.capnp
@@ -29,6 +29,7 @@ struct InitData {
   osVersion @18 :Text;
 
   dongleId @2 :Text;
+  bootlogId @22 :Text;
 
   deviceType @3 :DeviceType;
   version @4 :Text;


### PR DESCRIPTION
addresses the `add bootlog id to initData` requirement for logging more boot info

Related to https://github.com/commaai/openpilot/pull/32293