### PR TITLE
Handle peer shutdown correctly in ipc_sendrecv_with_fds

### DIFF
--- a/msgq/visionipc/visionipc.cc
+++ b/msgq/visionipc/visionipc.cc
@@ -90,7 +90,11 @@ int ipc_sendrecv_with_fds(bool send, int fd, void *buf, size_t buf_size, int* fd
     return sendmsg(fd, &msg, 0);
   } else {
     int r = recvmsg(fd, &msg, 0);
-    if (r < 0) return r;
+    if (r <= 0) {
+      // r == 0: peer closed connection (EOF)
+      // r < 0: error occurred (check errno)
+      return r;
+    }
 
     int recv_fds = 0;
     if (msg.msg_controllen > 0) {

--- a/msgq/visionipc/visionipc_client.cc
+++ b/msgq/visionipc/visionipc_client.cc
@@ -55,9 +55,14 @@ bool VisionIpcClient::connect(bool blocking){
   int fds[VISIONIPC_MAX_FDS];
   VisionBuf bufs[VISIONIPC_MAX_FDS];
   r = ipc_sendrecv_with_fds(false, socket_fd, &bufs, sizeof(bufs), fds, VISIONIPC_MAX_FDS, &num_buffers);
-  if (r < 0) {
+  if (r <= 0) {
     // only expected error is server shutting down
-    assert(errno == ECONNRESET);
+    if (r == 0) {
+      LOGE("server closed connection");
+    } else {
+      assert(errno == ECONNRESET);
+      LOGE("recv failed: %d", errno);
+    }
     close(socket_fd);
     return false;
   }
@@ -135,9 +140,14 @@ std::set<VisionStreamType> VisionIpcClient::getAvailableStreams(const std::strin
 
   VisionStreamType available_streams[VISION_STREAM_MAX] = {};
   r = ipc_sendrecv_with_fds(false, socket_fd, &available_streams, sizeof(available_streams), nullptr, 0, nullptr);
-  if (r < 0) {
-    // only expected error is server shutting down
-    assert(errno == ECONNRESET);
+  if (r <= 0) {
+     if (r == 0) {
+      LOGE("server closed connection");
+    } else {
+      // only expected error is server shutting down
+      assert(errno == ECONNRESET);
+      LOGE("recv failed: %d", errno);
+    }
     close(socket_fd);
     return {};
   }


### PR DESCRIPTION
Fixes a bug in `ipc_sendrecv_with_fds` where a clean peer shutdown (EOF) was not handled.
- recvmsg() == 0 → peer closed the socket cleanly (EOF). (example `close(fd)` or `shutdown(fd, SHUT_WR)`)
- recvmsg() == -1 with errno == ECONNRESET → connection reset unexpectedly (peer process crashed | TCP-level reset).

**Details:**

-  When the server closes the UNIX socket cleanly, [recvmsg()](https://linux.die.net/man/2/recvmsg)  returns 0 to indicate EOF.
-  Previous code did not handle this case, proceeding to process control messages from an empty connection.
-  This could cause `VisionIpcClient::connect` to return true even though no valid data was received.
-  The fix explicitly checks for r == 0 and handles peer shutdown gracefully.

This is a correctness/robustness fix; it can cause crashes or undefined behavior in some situations if not handled.

